### PR TITLE
feat: complete remaining platform foundations

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,26 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-04-26 - PR #27 セルフレビュー追加修正
+
+- **達成したタスク**:
+  - `feature/remaining-open-issues` の PR #27 をセルフレビューし、CI通過済みの差分を再確認。
+  - `apps/frontend/src/test/setup.ts` のテスト後処理を `document.body.replaceChildren()` から Testing Library `cleanup()` に変更。
+  - `@testing-library/react` は happy-dom の global document 初期化後に動的 import し、React effect の unmount cleanup が各テスト後に実行されるようにした。
+  - 修正コミット `729fd39 fix: run React cleanup after frontend tests` を push 済み。
+
+- **検証結果**:
+  - `bun test src/features/common/components/ToastProvider.test.tsx src/features/forms/components/ResearchNoteForm.test.tsx`: pass
+  - `cd apps/frontend && bunx tsc --noEmit`: pass
+  - `bun run lint:all`: pass
+  - `bun run test:all`: pass
+  - `cd apps/frontend && bun run test --coverage`: All files 100.00 / 100.00
+  - `cd apps/backend && bun run test --coverage`: All files 100.00 / 100.00
+  - PR #27 GitHub Actions `lint-and-test`: pass
+
+- **次回への申し送り事項**:
+  - フロントエンド test setup で Testing Library を使う場合は、DOM global 初期化前の静的 import を避けること。
+
 ### 2026-04-26 - 残Issueの基盤実装とdevelop向けPR作成
 
 - **達成したタスク**:

--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,28 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-04-26 - 残Issueの基盤実装とdevelop向けPR作成
+
+- **達成したタスク**:
+  - `develop` を `origin/develop` から最新化し、`feature/remaining-open-issues` ブランチを作成。
+  - Issue #24 は PR #25 が `develop` にマージ済みだったため completed としてクローズ。
+  - Issue #7/#8/#9/#11/#13/#14/#15 をまとめて解消する PR #27 を `develop` 向けに作成。
+  - バックエンドに RFC 7807 風の標準化エラーレスポンス、`requestId`、JSON構造化アクセスログ、同期API用 Bearer 認証ミドルウェアを追加。
+  - フロントエンドの root layout に `SiteHeader` / `SiteFooter` / `ToastProvider` を集約し、ページごとの重複レイアウトを削除。
+  - Toast 通知基盤、`useToast`、React Hook Form + zod の `ResearchNoteForm` サンプル基盤を追加。
+  - Playwright/E2E 廃止後の方針に合わせ、MSW の `x-test-scenario` 異常系をユニットテストで検証する形へ整理。
+  - `react-hook-form`, `@hookform/resolvers`, `zod` をフロントエンド依存に追加。
+
+- **検証結果**:
+  - `bun run lint:all`: pass
+  - `bun run test:all`: pass（frontend 23件、backend 73件）
+  - `cd apps/backend && bunx tsc --noEmit`: pass
+  - `cd apps/frontend && bunx tsc --noEmit`: pass
+
+- **次回への申し送り事項**:
+  - バックエンドの構造化ログはテスト実行時にもJSONログを出力する。必要ならテスト環境だけ logger を差し替え可能にする。
+  - #15 は E2E 復活ではなく、現行方針の MSW ユニットテストとしてクローズする設計判断。
+
 ### 2026-04-25 - 認証・Honoセキュリティ強化PR
 
 - **達成したタスク**:

--- a/apps/backend/bunfig.toml
+++ b/apps/backend/bunfig.toml
@@ -1,4 +1,4 @@
 [test]
 preload = ["./src/testSetup.ts"]
 coverageThreshold = 1.0
-coverageIgnorePatterns = ["src/interface/test/testHelpers.ts"]
+coveragePathIgnorePatterns = ["src/interface/test/testHelpers.ts", "src/infrastructure/database/schema.ts"]

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -2,13 +2,16 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
 import * as routes from "./interface/routes/openapi";
 import { cors } from "hono/cors";
-import { bearerAuth } from "hono/bearer-auth";
 import { secureHeaders } from "hono/secure-headers";
 import { auth } from "./infrastructure/auth/auth";
 import { getAllowedOrigins } from "./infrastructure/security/origins";
 
 // Middleware / Config
 import { diMiddleware } from "./interface/middleware/diMiddleware";
+import { handleAppError, handleNotFound } from "./interface/http/errorResponse";
+import { requestIdMiddleware } from "./interface/middleware/requestIdMiddleware";
+import { structuredLogger } from "./interface/middleware/structuredLogger";
+import { syncBearerAuth } from "./interface/middleware/syncBearerAuth";
 import { Bindings, AppVariables } from "./interface/types";
 
 // Controllers
@@ -36,6 +39,8 @@ export function resolveCorsOrigin(origin: string | undefined): string | undefine
 }
 
 app.use("*", secureHeaders());
+app.use("*", requestIdMiddleware());
+app.use("*", structuredLogger());
 
 app.use(
   "*",
@@ -68,7 +73,7 @@ export function validateStartupEnv(): void {
 validateStartupEnv();
 const apiToken = process.env.API_TOKEN as string;
 
-app.use("/api/v1/sync/*", bearerAuth({ token: apiToken }));
+app.use("/api/v1/sync/*", syncBearerAuth(apiToken));
 
 // 2.8 Auth 関連 (better-auth)
 app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
@@ -104,6 +109,9 @@ app.openapi(routes.calculateZigZagRoute, MarketController.calculateZigZag);
 app.openapi(routes.marketSessionsRoute, MarketController.getRecentSessions);
 app.openapi(routes.eventReplayRoute, MarketController.getEventReplay);
 app.openapi(routes.marketIndicatorsRoute, MarketController.getIndicators);
+
+app.notFound(handleNotFound);
+app.onError(handleAppError);
 
 /* Bun.serve でHTTPサーバーを起動 (Docker/VPS環境用) */
 const port = parseInt(process.env.PORT ?? "3000", 10);

--- a/apps/backend/src/interface/http/errorResponse.test.ts
+++ b/apps/backend/src/interface/http/errorResponse.test.ts
@@ -40,9 +40,32 @@ describe("errorResponse", () => {
 
     expect(res.status).toBe(401);
     expect(body).toMatchObject({
-      title: "Unauthorized",
+      title: "Application Error",
       status: 401,
       detail: "Unauthorized",
+      requestId: "test-request-id",
+    });
+  });
+
+  it("一般的なErrorを500レスポンスに変換すること", async () => {
+    const app = new Hono<{ Variables: { requestId: string } }>();
+    app.use("*", async (c, next) => {
+      c.set("requestId", "test-request-id");
+      await next();
+    });
+    app.get("/crash", () => {
+      throw new Error("unexpected boom");
+    });
+    app.onError(handleAppError);
+
+    const res = await app.request("/crash");
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toMatchObject({
+      title: "Internal Server Error",
+      status: 500,
+      detail: "Internal Server Error",
       requestId: "test-request-id",
     });
   });

--- a/apps/backend/src/interface/http/errorResponse.test.ts
+++ b/apps/backend/src/interface/http/errorResponse.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { handleAppError, handleNotFound } from "./errorResponse";
+
+describe("errorResponse", () => {
+  it("未定義ルートを標準化された404レスポンスに変換すること", async () => {
+    const app = new Hono<{ Variables: { requestId: string } }>();
+    app.use("*", async (c, next) => {
+      c.set("requestId", "test-request-id");
+      await next();
+    });
+    app.notFound(handleNotFound);
+
+    const res = await app.request("/missing");
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body).toMatchObject({
+      title: "Not Found",
+      status: 404,
+      instance: "/missing",
+      requestId: "test-request-id",
+    });
+  });
+
+  it("HTTPExceptionをステータス付きの標準化レスポンスに変換すること", async () => {
+    const app = new Hono<{ Variables: { requestId: string } }>();
+    app.use("*", async (c, next) => {
+      c.set("requestId", "test-request-id");
+      await next();
+    });
+    app.get("/error", () => {
+      throw new HTTPException(401, { message: "Unauthorized" });
+    });
+    app.onError(handleAppError);
+
+    const res = await app.request("/error");
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toMatchObject({
+      title: "Unauthorized",
+      status: 401,
+      detail: "Unauthorized",
+      requestId: "test-request-id",
+    });
+  });
+});

--- a/apps/backend/src/interface/http/errorResponse.ts
+++ b/apps/backend/src/interface/http/errorResponse.ts
@@ -50,6 +50,7 @@ export function handleNotFound(c: Context) {
  */
 export function handleAppError(err: Error, c: Context) {
   const status = err instanceof HTTPException ? err.status : 500;
+  const title = status === 500 ? "Internal Server Error" : "Application Error";
   const detail = status === 500 ? "Internal Server Error" : err.message;
   const requestId = c.get("requestId");
 
@@ -64,5 +65,5 @@ export function handleAppError(err: Error, c: Context) {
     }),
   );
 
-  return c.json(createProblemDetails(status, detail, detail, c.req.path, requestId), status);
+  return c.json(createProblemDetails(status, title, detail, c.req.path, requestId), status);
 }

--- a/apps/backend/src/interface/http/errorResponse.ts
+++ b/apps/backend/src/interface/http/errorResponse.ts
@@ -1,0 +1,68 @@
+import { HTTPException } from "hono/http-exception";
+import type { Context } from "hono";
+
+export type ProblemDetails = {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance: string;
+  requestId?: string;
+};
+
+/**
+ * createProblemDetails は API エラーを RFC 7807 風のJSON形式へ正規化します。
+ * @responsibility 例外・404応答をフロントエンドが一貫して扱えるエラー形式に変換する。
+ */
+export function createProblemDetails(
+  status: number,
+  title: string,
+  detail: string,
+  instance: string,
+  requestId?: string,
+): ProblemDetails {
+  return {
+    type: `https://httpstatuses.com/${status}`,
+    title,
+    status,
+    detail,
+    instance,
+    ...(requestId ? { requestId } : {}),
+  };
+}
+
+/**
+ * handleNotFound は未定義ルートへのレスポンスを生成します。
+ * @responsibility 404時も標準化されたエラーレスポンスを返す。
+ */
+export function handleNotFound(c: Context) {
+  const requestId = c.get("requestId");
+
+  return c.json(
+    createProblemDetails(404, "Not Found", "The requested resource was not found.", c.req.path, requestId),
+    404,
+  );
+}
+
+/**
+ * handleAppError はアプリケーション内で発生した例外をHTTPレスポンスへ変換します。
+ * @responsibility 未捕捉例外やHTTPExceptionを標準化されたJSONエラーとして返す。
+ */
+export function handleAppError(err: Error, c: Context) {
+  const status = err instanceof HTTPException ? err.status : 500;
+  const detail = status === 500 ? "Internal Server Error" : err.message;
+  const requestId = c.get("requestId");
+
+  console.error(
+    JSON.stringify({
+      level: "error",
+      message: err.message,
+      status,
+      path: c.req.path,
+      method: c.req.method,
+      requestId,
+    }),
+  );
+
+  return c.json(createProblemDetails(status, detail, detail, c.req.path, requestId), status);
+}

--- a/apps/backend/src/interface/middleware/requestIdMiddleware.ts
+++ b/apps/backend/src/interface/middleware/requestIdMiddleware.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareHandler } from "hono";
+import type { Bindings, AppVariables } from "../types";
+
+/**
+ * requestIdMiddleware はリクエスト単位の識別子を Context とレスポンスヘッダーへ設定します。
+ * @responsibility ログとエラーレスポンスを同じ requestId で追跡できるようにする。
+ */
+export function requestIdMiddleware(): MiddlewareHandler<{
+  Bindings: Bindings;
+  Variables: AppVariables;
+}> {
+  return async (c, next) => {
+    const requestId = c.req.header("x-request-id") ?? crypto.randomUUID();
+    c.set("requestId", requestId);
+    c.header("x-request-id", requestId);
+
+    await next();
+  };
+}

--- a/apps/backend/src/interface/middleware/structuredLogger.test.ts
+++ b/apps/backend/src/interface/middleware/structuredLogger.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { structuredLogger, type AccessLogEntry } from "./structuredLogger";
+
+describe("structuredLogger", () => {
+  it("リクエスト完了後に構造化されたアクセスログを出力すること", async () => {
+    const entries: AccessLogEntry[] = [];
+    const app = new Hono<{ Variables: { requestId: string } }>();
+    app.use("*", async (c, next) => {
+      c.set("requestId", "test-request-id");
+      await next();
+    });
+    app.use("*", structuredLogger((entry) => entries.push(entry)));
+    app.get("/health", (c) => c.json({ status: "ok" }));
+
+    const res = await app.request("/health");
+
+    expect(res.status).toBe(200);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      level: "info",
+      message: "http_request",
+      method: "GET",
+      path: "/health",
+      status: 200,
+      requestId: "test-request-id",
+    });
+    expect(entries[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/backend/src/interface/middleware/structuredLogger.ts
+++ b/apps/backend/src/interface/middleware/structuredLogger.ts
@@ -1,0 +1,41 @@
+import type { MiddlewareHandler } from "hono";
+import type { Bindings, AppVariables } from "../types";
+
+export type AccessLogEntry = {
+  level: "info";
+  message: "http_request";
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  requestId?: string;
+};
+
+export type AccessLogger = (entry: AccessLogEntry) => void;
+
+/**
+ * structuredLogger はHTTPアクセスログをJSON構造で出力するミドルウェアです。
+ * @responsibility method/path/status/duration/requestId を含む追跡しやすいアクセスログを記録する。
+ */
+export function structuredLogger(
+  logger: AccessLogger = (entry) => console.info(JSON.stringify(entry)),
+): MiddlewareHandler<{
+  Bindings: Bindings;
+  Variables: AppVariables;
+}> {
+  return async (c, next) => {
+    const startedAt = performance.now();
+
+    await next();
+
+    logger({
+      level: "info",
+      message: "http_request",
+      method: c.req.method,
+      path: c.req.path,
+      status: c.res.status,
+      durationMs: Math.round(performance.now() - startedAt),
+      requestId: c.get("requestId"),
+    });
+  };
+}

--- a/apps/backend/src/interface/middleware/syncBearerAuth.test.ts
+++ b/apps/backend/src/interface/middleware/syncBearerAuth.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { syncBearerAuth } from "./syncBearerAuth";
+
+describe("syncBearerAuth", () => {
+  it("Bearer token が一致する場合に同期APIへのアクセスを許可すること", async () => {
+    const app = new Hono();
+    app.use("/api/v1/sync/*", syncBearerAuth("expected-token"));
+    app.get("/api/v1/sync/status", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/v1/sync/status", {
+      headers: {
+        Authorization: "Bearer expected-token",
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("Bearer token がない場合に同期APIへのアクセスを拒否すること", async () => {
+    const app = new Hono();
+    app.use("/api/v1/sync/*", syncBearerAuth("expected-token"));
+    app.get("/api/v1/sync/status", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/v1/sync/status");
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/backend/src/interface/middleware/syncBearerAuth.ts
+++ b/apps/backend/src/interface/middleware/syncBearerAuth.ts
@@ -1,0 +1,14 @@
+import { bearerAuth } from "hono/bearer-auth";
+import type { MiddlewareHandler } from "hono";
+import type { Bindings, AppVariables } from "../types";
+
+/**
+ * syncBearerAuth はデータ同期APIを Bearer token で保護するミドルウェアです。
+ * @responsibility Authorization ヘッダーの Bearer token を検証し、同期APIへの未認証アクセスを拒否する。
+ */
+export function syncBearerAuth(token: string): MiddlewareHandler<{
+  Bindings: Bindings;
+  Variables: AppVariables;
+}> {
+  return bearerAuth({ token });
+}

--- a/apps/backend/src/interface/types.ts
+++ b/apps/backend/src/interface/types.ts
@@ -17,6 +17,7 @@ export type Bindings = {
  * AppVariables は Hono Context に保存される依存オブジェクトの型定義です。
  */
 export type AppVariables = {
+  requestId: string;
   syncRepo: SyncRepositoryPort;
   priceRepo: PriceRepositoryPort;
   zigzagRepo: ZigZagRepositoryPort;

--- a/apps/frontend/bunfig.toml
+++ b/apps/frontend/bunfig.toml
@@ -1,2 +1,4 @@
 [test]
 preload = ["./src/test/setup.ts"]
+coverageThreshold = 1.0
+coveragePathIgnorePatterns = ["src/test/handlers.ts", "src/test/server.ts", "src/test/setup.ts"]

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "bun test src/ --coverage --coverageThreshold=1.0"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "better-auth": "^1.6.4",
     "chart.js": "^4.5.1",
     "hono": "^4.12.9",
@@ -19,7 +20,9 @@
     "next": "16.2.1",
     "react": "19.2.4",
     "react-chartjs-2": "^5.3.1",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-hook-form": "^7.74.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.30.3",

--- a/apps/frontend/src/app/community/page.tsx
+++ b/apps/frontend/src/app/community/page.tsx
@@ -1,6 +1,4 @@
 import type { Metadata } from "next";
-import { SiteFooter } from "@/features/common/components/SiteFooter";
-import { SiteHeader } from "@/features/common/components/SiteHeader";
 
 export const metadata: Metadata = {
   title: "掲示板",
@@ -31,10 +29,6 @@ const discussionTopics = [
  */
 export default function CommunityPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center bg-[#f7f4ee] text-slate-900 selection:bg-amber-100">
-      <main className="w-full max-w-7xl px-4 py-6 text-slate-900 sm:px-6 lg:px-8">
-        <SiteHeader />
-
         <section className="grid gap-8 rounded-[2rem] border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 lg:grid-cols-[0.8fr_1.2fr] lg:p-10">
           <div className="space-y-5">
             <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-700">
@@ -60,9 +54,5 @@ export default function CommunityPage() {
             ))}
           </div>
         </section>
-
-        <SiteFooter />
-      </main>
-    </div>
   );
 }

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -1,6 +1,4 @@
 import type { Metadata } from "next";
-import { SiteFooter } from "@/features/common/components/SiteFooter";
-import { SiteHeader } from "@/features/common/components/SiteHeader";
 
 export const metadata: Metadata = {
   title: "考察ブログ",
@@ -31,10 +29,6 @@ const insightPosts = [
  */
 export default function InsightsPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center bg-[#f7f4ee] text-slate-900 selection:bg-amber-100">
-      <main className="w-full max-w-7xl px-4 py-6 text-slate-900 sm:px-6 lg:px-8">
-        <SiteHeader />
-
         <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white shadow-sm shadow-slate-200/60">
           <div className="border-b border-slate-100 p-6 lg:p-10">
             <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-700">
@@ -62,9 +56,5 @@ export default function InsightsPage() {
             ))}
           </div>
         </section>
-
-        <SiteFooter />
-      </main>
-    </div>
   );
 }

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { SiteFooter } from "@/features/common/components/SiteFooter";
+import { SiteHeader } from "@/features/common/components/SiteHeader";
+import { ToastProvider } from "@/features/common/components/ToastProvider";
 
 const siteUrl = new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com");
 const siteTitle = "fanda-dev | XAUUSD分析・GOLD分析ダッシュボード";
@@ -52,7 +55,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className="h-full antialiased">
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full">
+        <ToastProvider>
+          <div className="flex min-h-screen flex-col items-center bg-[#f7f4ee] text-slate-900 selection:bg-amber-100">
+            <main className="w-full max-w-7xl px-4 py-6 text-slate-900 sm:px-6 lg:px-8">
+              <SiteHeader />
+              {children}
+              <SiteFooter />
+            </main>
+          </div>
+        </ToastProvider>
+      </body>
     </html>
   );
 }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -4,9 +4,8 @@ import { ReplayArea } from '@/features/market-replay/components/ReplayArea';
 import ReplaySkeleton from '@/features/market-replay/components/ReplaySkeleton';
 import { SessionFactTimeline } from '@/features/sessions/components/SessionFactTimeline';
 import { getIndicators } from '@/features/common/api/getIndicators';
-import { SiteHeader } from '@/features/common/components/SiteHeader';
-import { SiteFooter } from '@/features/common/components/SiteFooter';
 import { LiveStatusBadge } from '@/features/sessions/components/LiveStatusBadge';
+import { ResearchNoteForm } from '@/features/forms/components/ResearchNoteForm';
 
 const valueHighlights = [
   {
@@ -47,13 +46,8 @@ export default async function DashboardPage({ searchParams }: PageProps) {
   const currentEvent = resolvedParams.event || defaultEvent;
 
   return (
-    <div className="flex min-h-screen flex-col items-center bg-[#f7f4ee] text-slate-900 selection:bg-amber-100">
-      <main className="w-full max-w-7xl px-4 py-6 text-slate-900 sm:px-6 lg:px-8">
-
-        {/* === 共通ヘッダー: タイトル・認証UI・ライブステータス === */}
-        <SiteHeader />
-
-        <section id="overview" className="mb-8 scroll-mt-8">
+    <>
+      <section id="overview" className="mb-8 scroll-mt-8">
           <div className="grid overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white shadow-sm shadow-slate-200/60 lg:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.55fr)]">
             <div className="space-y-10 p-6 sm:p-8 lg:p-10">
               <div className="max-w-4xl space-y-6">
@@ -154,36 +148,35 @@ export default async function DashboardPage({ searchParams }: PageProps) {
 
             {/* === Secondary Content: Session Fact Timeline === */}
             <aside id="session-timeline" className="scroll-mt-8">
-              <div className="rounded-3xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-200/60">
-                <div className="mb-5">
-                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
-                    Session Timeline
-                  </p>
-                  <h3 className="mt-2 text-lg font-semibold text-slate-950">
-                    セッション別の反応
-                  </h3>
-                  <p className="mt-2 text-sm leading-6 text-slate-500">
-                    イベントと時間帯の関係を横で見ながら、チャートの動きを確認できます。
-                  </p>
+              <div className="space-y-6">
+                <div className="rounded-3xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-200/60">
+                  <div className="mb-5">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                      Session Timeline
+                    </p>
+                    <h3 className="mt-2 text-lg font-semibold text-slate-950">
+                      セッション別の反応
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-500">
+                      イベントと時間帯の関係を横で見ながら、チャートの動きを確認できます。
+                    </p>
+                  </div>
+                  <Suspense
+                    fallback={
+                      <div className="animate-pulse space-y-4 pt-4">
+                        <div className="h-10 rounded bg-slate-100"></div>
+                        <div className="h-10 rounded bg-slate-100"></div>
+                      </div>
+                    }
+                  >
+                    <SessionFactTimeline />
+                  </Suspense>
                 </div>
-                <Suspense
-                  fallback={
-                    <div className="animate-pulse space-y-4 pt-4">
-                      <div className="h-10 rounded bg-slate-100"></div>
-                      <div className="h-10 rounded bg-slate-100"></div>
-                    </div>
-                  }
-                >
-                  <SessionFactTimeline />
-                </Suspense>
+                <ResearchNoteForm />
               </div>
             </aside>
           </div>
-        </section>
-
-        {/* === 共通フッター === */}
-        <SiteFooter />
-      </main>
-    </div>
+      </section>
+    </>
   );
 }

--- a/apps/frontend/src/features/common/api/getIndicators.test.ts
+++ b/apps/frontend/src/features/common/api/getIndicators.test.ts
@@ -2,8 +2,9 @@ import { expect, it, describe, mock, beforeEach } from "bun:test";
 import { getIndicators } from "./getIndicators";
 
 /* next/headers のモック化 */
+let requestHeaders = new Headers();
 mock.module("next/headers", () => ({
-  headers: () => Promise.resolve(new Headers()),
+  headers: () => Promise.resolve(requestHeaders),
 }));
 
 /* apiClient のモック化 */
@@ -25,6 +26,7 @@ mock.module("../../../lib/api/client", () => ({
 describe("getIndicators", () => {
   beforeEach(() => {
     getMock.mockClear();
+    requestHeaders = new Headers();
   });
 
   it("正常にデータを取得できた場合、JSON データを返すこと", async () => {
@@ -41,6 +43,20 @@ describe("getIndicators", () => {
     /* ## Assert ## */
     expect(getMock).toHaveBeenCalled();
     expect(result).toEqual(mockResponse);
+  });
+
+  it("x-test-scenario ヘッダーがある場合、API 呼び出しへ転送すること", async () => {
+    const mockResponse = { indicators: [] };
+    requestHeaders = new Headers({ "x-test-scenario": "error" });
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await getIndicators();
+
+    const init = getMock.mock.calls[0][1].init;
+    expect(init.headers["x-test-scenario"]).toBe("error");
   });
 
   it("API 呼び出しが失敗した場合、Error をスローすること", async () => {

--- a/apps/frontend/src/features/common/components/SiteFooter.tsx
+++ b/apps/frontend/src/features/common/components/SiteFooter.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 /**
  * SiteFooter はアプリケーション共通のフッターコンポーネントです。
  * @responsibility コピーライト表示とフッターナビゲーションリンクを提供する。
@@ -12,15 +14,15 @@ export function SiteFooter() {
         </p>
       </div>
       <div className="flex flex-wrap items-start gap-x-8 gap-y-3 font-medium">
-        <span className="cursor-pointer border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
+        <Link href="/privacy" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
           Privacy &amp; Security
-        </span>
-        <span className="cursor-pointer border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
+        </Link>
+        <Link href="/status" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
           Status
-        </span>
-        <span className="cursor-pointer border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
+        </Link>
+        <Link href="/api" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
           API
-        </span>
+        </Link>
       </div>
     </footer>
   );

--- a/apps/frontend/src/features/common/components/SiteHeader.tsx
+++ b/apps/frontend/src/features/common/components/SiteHeader.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { AuthUI } from "@/features/auth/components/AuthUI";
 
 const navigationItems = [
@@ -12,6 +15,8 @@ const navigationItems = [
  * @responsibility アプリタイトル、ページナビゲーション、認証UIを統合して表示する。
  */
 export function SiteHeader() {
+  const pathname = usePathname();
+
   return (
     <header className="mb-10 rounded-3xl border border-slate-200/80 bg-white/75 px-5 py-4 shadow-sm shadow-slate-200/50 backdrop-blur md:mb-12 md:px-6">
       {/* タイトルと認証UIを横並び */}
@@ -32,7 +37,10 @@ export function SiteHeader() {
               <Link
                 key={item.href}
                 href={item.href}
-                className="font-medium text-slate-500 transition-colors hover:text-slate-950"
+                aria-current={pathname === item.href ? "page" : undefined}
+                className={`font-medium transition-colors hover:text-slate-950 ${
+                  pathname === item.href ? "text-slate-950" : "text-slate-500"
+                }`}
               >
                 {item.label}
               </Link>

--- a/apps/frontend/src/features/common/components/ToastProvider.test.tsx
+++ b/apps/frontend/src/features/common/components/ToastProvider.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ToastProvider, useToast } from "./ToastProvider";
+
+function ToastTrigger() {
+  const { showToast } = useToast();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        showToast({
+          title: "保存しました",
+          description: "トースト通知のテストです。",
+          variant: "success",
+        })
+      }
+    >
+      通知を表示
+    </button>
+  );
+}
+
+describe("ToastProvider", () => {
+  it("useToast から通知を表示できること", () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "通知を表示" }));
+
+    expect(screen.getByText("保存しました")).toBeDefined();
+    expect(screen.getByText("トースト通知のテストです。")).toBeDefined();
+  });
+});

--- a/apps/frontend/src/features/common/components/ToastProvider.test.tsx
+++ b/apps/frontend/src/features/common/components/ToastProvider.test.tsx
@@ -34,4 +34,47 @@ describe("ToastProvider", () => {
     expect(screen.getByText("保存しました")).toBeDefined();
     expect(screen.getByText("トースト通知のテストです。")).toBeDefined();
   });
+
+  it("閉じるボタンで通知を破棄できること", () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "通知を表示" }));
+    fireEvent.click(screen.getByRole("button", { name: "通知を閉じる" }));
+
+    expect(screen.queryByText("保存しました")).toBeNull();
+  });
+
+  it("アンマウント時に保留中の自動クローズタイマーを解放すること", () => {
+    const originalClearTimeout = window.clearTimeout;
+    const clearedTimeouts: unknown[] = [];
+    window.clearTimeout = ((timeoutId?: unknown) => {
+      if (timeoutId) {
+        clearedTimeouts.push(timeoutId);
+      }
+    }) as typeof window.clearTimeout;
+    const { unmount } = render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "通知を表示" }));
+    unmount();
+    window.clearTimeout = originalClearTimeout;
+
+    expect(clearedTimeouts.length).toBeGreaterThan(0);
+  });
+
+  it("Provider 外で useToast を使った場合にエラーを投げること", () => {
+    function InvalidToastConsumer() {
+      useToast();
+      return null;
+    }
+
+    expect(() => render(<InvalidToastConsumer />)).toThrow("useToast must be used within ToastProvider");
+  });
 });

--- a/apps/frontend/src/features/common/components/ToastProvider.tsx
+++ b/apps/frontend/src/features/common/components/ToastProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 type ToastVariant = "success" | "error" | "info";
 
@@ -32,18 +32,34 @@ const variantStyles: Record<ToastVariant, string> = {
  */
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const timeoutIds = useRef<Map<string, number>>(new Map());
 
   const dismissToast = useCallback((id: string) => {
+    const timeoutId = timeoutIds.current.get(id);
+    if (timeoutId) {
+      window.clearTimeout(timeoutId);
+      timeoutIds.current.delete(id);
+    }
     setToasts((current) => current.filter((toast) => toast.id !== id));
   }, []);
 
   const showToast = useCallback((toast: ToastInput) => {
     const id = crypto.randomUUID();
     setToasts((current) => [...current.slice(-2), { ...toast, id }]);
-    window.setTimeout(() => dismissToast(id), 4000);
+    const timeoutId = window.setTimeout(dismissToast, 4000, id);
+    timeoutIds.current.set(id, timeoutId);
   }, [dismissToast]);
 
   const value = useMemo(() => ({ showToast, dismissToast }), [dismissToast, showToast]);
+
+  useEffect(() => {
+    const currentTimeoutIds = timeoutIds.current;
+
+    return () => {
+      currentTimeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId));
+      currentTimeoutIds.clear();
+    };
+  }, []);
 
   return (
     <ToastContext.Provider value={value}>

--- a/apps/frontend/src/features/common/components/ToastProvider.tsx
+++ b/apps/frontend/src/features/common/components/ToastProvider.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+type ToastVariant = "success" | "error" | "info";
+
+type ToastMessage = {
+  id: string;
+  title: string;
+  description?: string;
+  variant: ToastVariant;
+};
+
+type ToastInput = Omit<ToastMessage, "id">;
+
+type ToastContextValue = {
+  showToast: (toast: ToastInput) => void;
+  dismissToast: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const variantStyles: Record<ToastVariant, string> = {
+  success: "border-emerald-200 bg-emerald-50 text-emerald-950",
+  error: "border-red-200 bg-red-50 text-red-950",
+  info: "border-slate-200 bg-white text-slate-950",
+};
+
+/**
+ * ToastProvider はアプリ全体で利用できるトースト通知基盤です。
+ * @responsibility 任意のクライアントコンポーネントから一時的な通知を表示・破棄できる状態を提供する。
+ */
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((toast: ToastInput) => {
+    const id = crypto.randomUUID();
+    setToasts((current) => [...current.slice(-2), { ...toast, id }]);
+    window.setTimeout(() => dismissToast(id), 4000);
+  }, [dismissToast]);
+
+  const value = useMemo(() => ({ showToast, dismissToast }), [dismissToast, showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-label="Notifications"
+        className="pointer-events-none fixed bottom-5 right-5 z-50 flex w-[min(22rem,calc(100vw-2.5rem))] flex-col gap-3"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            role="status"
+            className={`pointer-events-auto rounded-2xl border p-4 shadow-lg shadow-slate-200/70 ${variantStyles[toast.variant]}`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold">{toast.title}</p>
+                {toast.description ? (
+                  <p className="mt-1 text-sm leading-6 opacity-75">{toast.description}</p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={() => dismissToast(toast.id)}
+                className="rounded-full px-2 text-lg leading-none opacity-50 transition-opacity hover:opacity-100"
+                aria-label="通知を閉じる"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+/**
+ * useToast はトースト通知を表示するためのフックです。
+ * @responsibility ToastProvider 配下のコンポーネントへ通知表示APIを提供する。
+ */
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider");
+  }
+
+  return context;
+}

--- a/apps/frontend/src/features/forms/components/ResearchNoteForm.test.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNoteForm.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ToastProvider } from "@/features/common/components/ToastProvider";
+import { ResearchNoteForm } from "./ResearchNoteForm";
+
+describe("ResearchNoteForm", () => {
+  it("入力値が不正な場合に zod のバリデーションエラーを表示すること", async () => {
+    render(
+      <ToastProvider>
+        <ResearchNoteForm />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "メモを保存" }));
+
+    expect(await screen.findByText("タイトルを入力してください")).toBeDefined();
+    expect(await screen.findByText("メモは10文字以上で入力してください")).toBeDefined();
+  });
+
+  it("入力値が正しい場合に保存トーストを表示すること", async () => {
+    render(
+      <ToastProvider>
+        <ResearchNoteForm />
+      </ToastProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "CPI前後の値動き" },
+    });
+    fireEvent.change(screen.getByLabelText("メモ"), {
+      target: { value: "発表直後とNY後半の戻りを比較する" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "メモを保存" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("リサーチメモを保存しました")).toBeDefined();
+    });
+  });
+});

--- a/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { useToast } from "@/features/common/components/ToastProvider";
+
+const researchNoteSchema = z.object({
+  title: z.string().min(1, "タイトルを入力してください").max(60, "タイトルは60文字以内で入力してください"),
+  note: z.string().min(10, "メモは10文字以上で入力してください").max(240, "メモは240文字以内で入力してください"),
+});
+
+type ResearchNoteFormValues = z.infer<typeof researchNoteSchema>;
+
+/**
+ * ResearchNoteForm は React Hook Form と zod を組み合わせたサンプルフォームです。
+ * @responsibility 今後の設定画面や投稿フォームで再利用する入力検証・送信フィードバックの土台を示す。
+ */
+export function ResearchNoteForm() {
+  const { showToast } = useToast();
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<ResearchNoteFormValues>({
+    resolver: zodResolver(researchNoteSchema),
+    defaultValues: {
+      title: "",
+      note: "",
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    showToast({
+      title: "リサーチメモを保存しました",
+      description: `${values.title} をローカル確認用のサンプルとして受け付けました。`,
+      variant: "success",
+    });
+    reset();
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-700">
+          Form Foundation
+        </p>
+        <h3 className="mt-2 text-lg font-semibold text-slate-950">リサーチメモのサンプルフォーム</h3>
+        <p className="mt-2 text-sm leading-6 text-slate-500">
+          React Hook Form と zod による型安全な入力検証の基盤です。
+        </p>
+      </div>
+
+      <label className="block space-y-2">
+        <span className="text-sm font-semibold text-slate-700">タイトル</span>
+        <input
+          {...register("title")}
+          className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition-colors focus:border-amber-500"
+          placeholder="例: CPI前後の値動き"
+        />
+        {errors.title ? <p className="text-xs font-medium text-red-600">{errors.title.message}</p> : null}
+      </label>
+
+      <label className="block space-y-2">
+        <span className="text-sm font-semibold text-slate-700">メモ</span>
+        <textarea
+          {...register("note")}
+          className="min-h-28 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition-colors focus:border-amber-500"
+          placeholder="見返したい観点を10文字以上で入力"
+        />
+        {errors.note ? <p className="text-xs font-medium text-red-600">{errors.note.message}</p> : null}
+      </label>
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="inline-flex rounded-xl bg-slate-950 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        メモを保存
+      </button>
+    </form>
+  );
+}

--- a/apps/frontend/src/features/market-replay/api/getReplayData.test.ts
+++ b/apps/frontend/src/features/market-replay/api/getReplayData.test.ts
@@ -2,8 +2,9 @@ import { expect, it, describe, mock, beforeEach } from "bun:test";
 import { getReplayData } from "./getReplayData";
 
 /* next/headers のモック化 */
+let requestHeaders = new Headers();
 mock.module("next/headers", () => ({
-  headers: () => Promise.resolve(new Headers()),
+  headers: () => Promise.resolve(requestHeaders),
 }));
 
 /* apiClient のモック化 */
@@ -25,6 +26,7 @@ mock.module("../../../lib/api/client", () => ({
 describe("getReplayData", () => {
   beforeEach(() => {
     getMock.mockClear();
+    requestHeaders = new Headers();
   });
 
   it("正常にデータを取得できた場合、JSON データを返すこと", async () => {
@@ -43,6 +45,20 @@ describe("getReplayData", () => {
     // 引数のチェック（Hono RPC クライアントの形式）
     expect(getMock.mock.calls[0][0].query.event).toBe("TestEvent");
     expect(result).toEqual(mockResponse);
+  });
+
+  it("x-test-scenario ヘッダーがある場合、API 呼び出しへ転送すること", async () => {
+    const mockResponse = { previousEvent: null, candles: [], historicalStats: [] };
+    requestHeaders = new Headers({ "x-test-scenario": "error" });
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await getReplayData("TestEvent");
+
+    const init = getMock.mock.calls[0][1].init;
+    expect(init.headers["x-test-scenario"]).toBe("error");
   });
 
   it("API 呼び出しがエラー（ok: false）の場合、Error をスローすること", async () => {

--- a/apps/frontend/src/features/sessions/api/getSessions.test.ts
+++ b/apps/frontend/src/features/sessions/api/getSessions.test.ts
@@ -2,8 +2,9 @@ import { expect, it, describe, mock, beforeEach } from "bun:test";
 import { getSessions } from "./getSessions";
 
 /* next/headers のモック化 */
+let requestHeaders = new Headers();
 mock.module("next/headers", () => ({
-  headers: () => Promise.resolve(new Headers()),
+  headers: () => Promise.resolve(requestHeaders),
 }));
 
 /* apiClient のモック化 */
@@ -25,6 +26,7 @@ mock.module("../../../lib/api/client", () => ({
 describe("getSessions", () => {
   beforeEach(() => {
     getMock.mockClear();
+    requestHeaders = new Headers();
   });
 
   it("正常にデータを取得できた場合、JSON データを返すこと", async () => {
@@ -42,6 +44,20 @@ describe("getSessions", () => {
     expect(getMock).toHaveBeenCalled();
     expect(getMock.mock.calls[0][0].query.limit).toBe("5");
     expect(result).toEqual(mockResponse);
+  });
+
+  it("x-test-scenario ヘッダーがある場合、API 呼び出しへ転送すること", async () => {
+    const mockResponse = { sessions: [], currentCondition: "Small" };
+    requestHeaders = new Headers({ "x-test-scenario": "empty" });
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await getSessions(3);
+
+    const init = getMock.mock.calls[0][1].init;
+    expect(init.headers["x-test-scenario"]).toBe("empty");
   });
 
   it("API 呼び出しが失敗した場合、Error をスローすること", async () => {

--- a/apps/frontend/src/test/handlers.test.ts
+++ b/apps/frontend/src/test/handlers.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "bun:test";
 
 describe("MSW abnormal scenarios", () => {
+  it("同期ステータスAPIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/sync/status");
+    const body = await res.json() as { syncHealth: string };
+
+    expect(res.status).toBe(200);
+    expect(body.syncHealth).toBe("Healthy");
+  });
+
+  it("x-test-scenario=error で同期ステータスAPIの500応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/sync/status", {
+      headers: {
+        "x-test-scenario": "error",
+      },
+    });
+
+    expect(res.status).toBe(500);
+  });
+
   it("x-test-scenario=error でセッションAPIの500応答を再現できること", async () => {
     const res = await fetch("http://localhost:3000/api/v1/market/sessions", {
       headers: {
@@ -17,9 +35,64 @@ describe("MSW abnormal scenarios", () => {
         "x-test-scenario": "empty",
       },
     });
-    const body = await res.json();
+    const body = await res.json() as { sessions: unknown[]; currentCondition: string };
 
     expect(res.status).toBe(200);
     expect(body).toEqual({ sessions: [], currentCondition: "Small" });
+  });
+
+  it("セッションAPIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/market/sessions");
+    const body = await res.json() as { sessions: Array<{ sessionName: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.sessions[0].sessionName).toBe("NY_Open");
+  });
+
+  it("指標一覧APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/market/indicators");
+    const body = await res.json() as { indicators: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.indicators).toContain("[USD] CPI");
+  });
+
+  it("再現データAPIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/market/replay?event=CPI");
+    const body = await res.json() as { previousEvent: { eventsLinked: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.previousEvent.eventsLinked).toBe("CPI");
+  });
+
+  it("未ログイン時の認証セッションAPIは null を返すこと", async () => {
+    const res = await fetch("http://localhost:3000/api/auth/get-session");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toBeNull();
+  });
+
+  it("ログイン済みCookieがある場合の認証セッションAPIを再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/auth/get-session", {
+      headers: {
+        cookie: "better-auth.session_token=mock_session_token",
+      },
+    });
+    const body = await res.json() as { user: { name: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.user.name).toBe("Somah (Mock)");
+  });
+
+  it("サインアウトAPIの成功応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/auth/sign-out", {
+      method: "POST",
+    });
+    const body = await res.json() as { success: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(res.headers.get("set-cookie")).toContain("Max-Age=0");
   });
 });

--- a/apps/frontend/src/test/handlers.test.ts
+++ b/apps/frontend/src/test/handlers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+describe("MSW abnormal scenarios", () => {
+  it("x-test-scenario=error でセッションAPIの500応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/market/sessions", {
+      headers: {
+        "x-test-scenario": "error",
+      },
+    });
+
+    expect(res.status).toBe(500);
+  });
+
+  it("x-test-scenario=empty で空のセッション一覧を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/market/sessions", {
+      headers: {
+        "x-test-scenario": "empty",
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ sessions: [], currentCondition: "Small" });
+  });
+});

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -19,5 +19,8 @@ global.HTMLDivElement = window.HTMLDivElement as unknown as typeof HTMLDivElemen
 
 /* MSW: テストスイート開始前に起動し、各テスト後にハンドラーをリセット、終了時にクローズする */
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  document.body.replaceChildren();
+  server.resetHandlers();
+});
 afterAll(() => server.close());

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -17,10 +17,12 @@ global.CustomEvent = window.CustomEvent as unknown as typeof CustomEvent;
 global.HTMLElement = window.HTMLElement as unknown as typeof HTMLElement;
 global.HTMLDivElement = window.HTMLDivElement as unknown as typeof HTMLDivElement;
 
+const { cleanup } = await import('@testing-library/react');
+
 /* MSW: テストスイート開始前に起動し、各テスト後にハンドラーをリセット、終了時にクローズする */
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
-  document.body.replaceChildren();
+  cleanup();
   server.resetHandlers();
 });
 afterAll(() => server.close());

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "better-auth": "^1.6.4",
         "chart.js": "^4.5.1",
         "hono": "^4.12.9",
@@ -44,6 +45,8 @@
         "react": "19.2.4",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.74.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.30.3",
@@ -275,6 +278,8 @@
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -460,6 +465,8 @@
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -1280,6 +1287,8 @@
     "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-hook-form": ["react-hook-form@7.74.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #7
Closes #8
Closes #9
Closes #11
Closes #13
Closes #14
Closes #15

# Todo

- [x] Backend: RFC 7807風の標準化エラーレスポンスと 404 / onError ハンドリングを追加
- [x] Backend: requestId と JSON 構造化アクセスログを追加
- [x] Backend: 同期API用 Bearer 認証を専用ミドルウェア化し、認証テストを追加
- [x] Frontend: root layout に共通 Header / Footer / ToastProvider を集約
- [x] Frontend: Toast 通知基盤と `useToast` を追加
- [x] Frontend: React Hook Form + zod のサンプルフォーム基盤を追加
- [x] Frontend: E2E廃止後の方針に合わせ、MSW異常系シナリオをユニットテストで検証

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all
cd apps/backend && bunx tsc --noEmit
cd apps/frontend && bunx tsc --noEmit
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- `bun run lint:all`: pass
- `bun run test:all`: pass（frontend 23 tests / backend 73 tests）
- `cd apps/backend && bunx tsc --noEmit`: pass
- `cd apps/frontend && bunx tsc --noEmit`: pass

</details>

# Related Links

- #24 は PR #25 が `develop` にマージ済みだったため completed としてクローズ済み

Made with [Cursor](https://cursor.com)