### PR TITLE
[FE/BE] 掲示板APIの実装とページのデータ表示切り替え (#28 #29)

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,26 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-04-28 - Issue #29 掲示板一覧のAPI接続
+
+- **達成したタスク**:
+  - `feature/issue-29-community-api-list` ブランチを `develop` から作成。
+  - `/community` の固定モック配列を削除し、`getCommunityThreads()` 経由で掲示板投稿一覧APIを取得する構成へ変更。
+  - `CommunityThreadList` コンポーネントを追加し、投稿一覧表示と空状態を分離。
+  - `apps/frontend/src/app/community/loading.tsx` を追加し、掲示板ページの読み込み状態を表示。
+  - MSWハンドラーに `/api/v1/community/threads` の正常・空・500応答を追加。
+  - API取得・表示コンポーネント・MSWハンドラーのテストを追加。
+
+- **検証結果**:
+  - `cd apps/frontend && bun run lint`: pass
+  - `cd apps/frontend && bunx tsc --noEmit`: pass
+  - `cd apps/frontend && bun test src/`: 45 pass / 0 fail
+  - `cd apps/frontend && bun run build`: Node.js 20.18.2 のため失敗。Vite 8 / vinext が Node.js 20.19+ または 22.12+ を要求し、`node:fs/promises.glob` が利用できない。
+
+- **次回への申し送り事項**:
+  - Issue #29 はフロントエンド側のAPI接続実装。実運用で一覧表示するには依存Issue #28 のバックエンドAPI実装が必要。
+  - 期待エンドポイントは `/api/v1/community/threads`、レスポンスは `{ threads: CommunityThread[] }`。
+
 ### 2026-04-26 - PR #27 セルフレビュー追加修正
 
 - **達成したタスク**:

--- a/apps/backend/src/application/port/communityThreadRepositoryPort.ts
+++ b/apps/backend/src/application/port/communityThreadRepositoryPort.ts
@@ -1,0 +1,17 @@
+import { CommunityThread, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+
+/**
+ * CommunityThreadRepositoryPort は掲示板スレッドを管理するリポジトリインターフェースです。
+ * @responsibility: スレッドの一覧取得・新規作成を担当する。
+ */
+export interface CommunityThreadRepositoryPort {
+  /**
+   * 掲示板スレッド一覧を新しい順で取得します。
+   */
+  findAll(limit: number): Promise<CommunityThread[]>;
+
+  /**
+   * 新規スレッドを作成して返します。
+   */
+  create(input: CreateCommunityThreadInput): Promise<CommunityThread>;
+}

--- a/apps/backend/src/application/use_case/createCommunityThreadUseCase.ts
+++ b/apps/backend/src/application/use_case/createCommunityThreadUseCase.ts
@@ -1,0 +1,14 @@
+import { CommunityThreadRepositoryPort } from '../port/communityThreadRepositoryPort';
+import { CommunityThread, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+
+/**
+ * CreateCommunityThreadUseCase は新規掲示板スレッドを作成するユースケースです。
+ * @responsibility: バリデーション済みの入力を受け取り、リポジトリを通じてスレッドを永続化する。
+ */
+export class CreateCommunityThreadUseCase {
+  constructor(private readonly repo: CommunityThreadRepositoryPort) {}
+
+  async execute(input: CreateCommunityThreadInput): Promise<CommunityThread> {
+    return this.repo.create(input);
+  }
+}

--- a/apps/backend/src/application/use_case/getCommunityThreadsUseCase.ts
+++ b/apps/backend/src/application/use_case/getCommunityThreadsUseCase.ts
@@ -1,0 +1,14 @@
+import { CommunityThreadRepositoryPort } from '../port/communityThreadRepositoryPort';
+import { CommunityThread } from '../../domain/entities/communityThread';
+
+/**
+ * GetCommunityThreadsUseCase は掲示板スレッド一覧を取得するユースケースです。
+ * @responsibility: リポジトリを通じてスレッド一覧を新しい順で返す。
+ */
+export class GetCommunityThreadsUseCase {
+  constructor(private readonly repo: CommunityThreadRepositoryPort) {}
+
+  async execute(limit = 50): Promise<CommunityThread[]> {
+    return this.repo.findAll(limit);
+  }
+}

--- a/apps/backend/src/application/use_case/test/createCommunityThreadUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/createCommunityThreadUseCase.test.ts
@@ -1,0 +1,60 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { CreateCommunityThreadUseCase } from '../createCommunityThreadUseCase';
+import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
+import { CommunityThread, CreateCommunityThreadInput } from '../../../domain/entities/communityThread';
+
+/**
+ * CreateCommunityThreadUseCase Unit Tests
+ * @responsibility: スレッド作成のビジネスロジックを検証する。
+ */
+describe('CreateCommunityThreadUseCase (Unit Tests)', () => {
+  const mockCreated: CommunityThread = {
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    title: 'NFP後の戻りについて',
+    body: 'NFP直後のスプレッド拡大後、戻り幅が気になります。',
+    category: 'Market Discussion',
+    replyCount: 0,
+    createdAt: '2026-04-10T09:00:00.000Z',
+  };
+
+  const validInput: CreateCommunityThreadInput = {
+    title: 'NFP後の戻りについて',
+    body: 'NFP直後のスプレッド拡大後、戻り幅が気になります。',
+    category: 'Market Discussion',
+  };
+
+  describe('正常系', () => {
+    it('入力を渡してリポジトリの create を呼び出し、作成されたスレッドを返すこと', async () => {
+      // ## Arrange ##
+      const createMock = mock(() => Promise.resolve(mockCreated));
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: mock(() => Promise.resolve([])),
+        create: createMock,
+      };
+      const useCase = new CreateCommunityThreadUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute(validInput);
+
+      // ## Assert ##
+      expect(createMock).toHaveBeenCalledWith(validInput);
+      expect(result.id).toBe(mockCreated.id);
+      expect(result.title).toBe(mockCreated.title);
+      expect(result.replyCount).toBe(0);
+    });
+  });
+
+  describe('異常系', () => {
+    it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
+      // ## Arrange ##
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: mock(() => Promise.resolve([])),
+        create: mock(() => Promise.reject(new Error('INSERT失敗'))),
+      };
+      const useCase = new CreateCommunityThreadUseCase(mockRepo);
+
+      // ## Act & Assert ##
+      await expect(useCase.execute(validInput)).rejects.toThrow('INSERT失敗');
+    });
+  });
+});

--- a/apps/backend/src/application/use_case/test/getCommunityThreadsUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/getCommunityThreadsUseCase.test.ts
@@ -1,0 +1,83 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { GetCommunityThreadsUseCase } from '../getCommunityThreadsUseCase';
+import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
+import { CommunityThread } from '../../../domain/entities/communityThread';
+
+/**
+ * GetCommunityThreadsUseCase Unit Tests
+ * @responsibility: スレッド一覧取得のビジネスロジックを検証する。
+ */
+describe('GetCommunityThreadsUseCase (Unit Tests)', () => {
+  const mockThread: CommunityThread = {
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    title: 'CPI発表前後のXAUUSDの値幅について',
+    body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+    category: 'Market Discussion',
+    replyCount: 12,
+    createdAt: '2026-04-01T12:00:00.000Z',
+  };
+
+  describe('正常系', () => {
+    it('リポジトリが返したスレッド一覧をそのまま返すこと', async () => {
+      // ## Arrange ##
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: mock(() => Promise.resolve([mockThread])),
+        create: mock(() => Promise.resolve(mockThread)),
+      };
+      const useCase = new GetCommunityThreadsUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute();
+
+      // ## Assert ##
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockThread.id);
+      expect(result[0].title).toBe(mockThread.title);
+    });
+
+    it('リポジトリが空配列を返した場合、空配列を返すこと', async () => {
+      // ## Arrange ##
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: mock(() => Promise.resolve([])),
+        create: mock(() => Promise.resolve(mockThread)),
+      };
+      const useCase = new GetCommunityThreadsUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute();
+
+      // ## Assert ##
+      expect(result).toHaveLength(0);
+    });
+
+    it('デフォルト limit (50) で findAll を呼び出すこと', async () => {
+      // ## Arrange ##
+      const findAllMock = mock(() => Promise.resolve([mockThread]));
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: findAllMock,
+        create: mock(() => Promise.resolve(mockThread)),
+      };
+      const useCase = new GetCommunityThreadsUseCase(mockRepo);
+
+      // ## Act ##
+      await useCase.execute();
+
+      // ## Assert ##
+      expect(findAllMock).toHaveBeenCalledWith(50);
+    });
+  });
+
+  describe('異常系', () => {
+    it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
+      // ## Arrange ##
+      const mockRepo: CommunityThreadRepositoryPort = {
+        findAll: mock(() => Promise.reject(new Error('DB接続エラー'))),
+        create: mock(() => Promise.resolve(mockThread)),
+      };
+      const useCase = new GetCommunityThreadsUseCase(mockRepo);
+
+      // ## Act & Assert ##
+      await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+    });
+  });
+});

--- a/apps/backend/src/domain/entities/communityThread.ts
+++ b/apps/backend/src/domain/entities/communityThread.ts
@@ -1,0 +1,40 @@
+import { z } from '@hono/zod-openapi';
+
+/**
+ * CommunityThreadSchema は掲示板スレッドのドメインスキーマです。
+ * @responsibility: スレッドの識別情報・内容・カテゴリ・返信数・作成日時を保持する。
+ */
+export const CommunityThreadSchema = z.object({
+  id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', description: 'スレッドID' }),
+  title: z.string().min(1).max(200).openapi({ example: 'CPI発表前後のXAUUSDの値幅について', description: 'スレッドタイトル' }),
+  body: z.string().min(1).max(5000).openapi({ example: '前回CPIでは発表直後の初動より…', description: 'スレッド本文' }),
+  category: z.string().openapi({ example: 'Market Discussion', description: 'カテゴリ' }),
+  replyCount: z.number().int().nonnegative().openapi({ example: 12, description: '返信数' }),
+  createdAt: z.string().datetime().openapi({ example: '2026-04-01T12:00:00.000Z', description: '作成日時（ISO 8601）' }),
+}).openapi('CommunityThread');
+
+export type CommunityThread = z.infer<typeof CommunityThreadSchema>;
+
+/**
+ * CreateCommunityThreadInputSchema は新規スレッド作成時のバリデーションスキーマです。
+ * @responsibility: タイトル・本文・カテゴリの基本バリデーションを行う。
+ */
+export const CreateCommunityThreadInputSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'タイトルは1文字以上で入力してください')
+    .max(200, 'タイトルは200文字以内で入力してください')
+    .openapi({ example: 'CPI発表前後のXAUUSDの値幅について', description: 'スレッドタイトル' }),
+  body: z
+    .string()
+    .min(1, '本文は1文字以上で入力してください')
+    .max(5000, '本文は5000文字以内で入力してください')
+    .openapi({ example: '前回CPIでは発表直後の初動より…', description: 'スレッド本文' }),
+  category: z
+    .string()
+    .max(50, 'カテゴリは50文字以内で入力してください')
+    .default('General')
+    .openapi({ example: 'Market Discussion', description: 'カテゴリ' }),
+}).openapi('CreateCommunityThreadInput');
+
+export type CreateCommunityThreadInput = z.infer<typeof CreateCommunityThreadInputSchema>;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -17,6 +17,7 @@ import { Bindings, AppVariables } from "./interface/types";
 // Controllers
 import { MarketController } from "./interface/controller/marketController";
 import { SyncController } from "./interface/controller/syncController";
+import { CommunityController } from "./interface/controller/communityController";
 
 /**
  * Gold Volatility Bunseki API (Hono / Bun.serve)
@@ -109,6 +110,10 @@ app.openapi(routes.calculateZigZagRoute, MarketController.calculateZigZag);
 app.openapi(routes.marketSessionsRoute, MarketController.getRecentSessions);
 app.openapi(routes.eventReplayRoute, MarketController.getEventReplay);
 app.openapi(routes.marketIndicatorsRoute, MarketController.getIndicators);
+
+// Community Board
+app.openapi(routes.communityThreadsRoute, CommunityController.getThreads);
+app.openapi(routes.createCommunityThreadRoute, CommunityController.createThread);
 
 app.notFound(handleNotFound);
 app.onError(handleAppError);

--- a/apps/backend/src/infrastructure/database/schema.ts
+++ b/apps/backend/src/infrastructure/database/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, real, integer, boolean, uniqueIndex, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, text, real, integer, boolean, uniqueIndex, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const prices = pgTable('prices', {
   timestamp: text('timestamp').primaryKey(),
@@ -62,6 +62,20 @@ export const syncStatus = pgTable('sync_status', {
   lastEventAt: text('last_event_at'),
   totalCandles: integer('total_candles').default(0).notNull(),
   syncHealth: text('sync_health').default('Healthy').notNull(),
+});
+
+// ==========================================
+// Community Board Tables
+// ==========================================
+
+export const communityThreads = pgTable('community_threads', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  category: text('category').notNull().default('General'),
+  replyCount: integer('reply_count').notNull().default(0),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
 
 // ==========================================

--- a/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
+++ b/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
@@ -40,7 +40,7 @@ export class DrizzleCommunityThreadRepository implements CommunityThreadReposito
       .values({
         title: input.title,
         body: input.body,
-        category: input.category ?? 'General',
+        category: input.category,
       })
       .returning();
 

--- a/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
+++ b/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
@@ -1,0 +1,56 @@
+import { CommunityThreadRepositoryPort } from '../../application/port/communityThreadRepositoryPort';
+import { CommunityThread, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+import { DbType } from '../database/db';
+import { communityThreads } from '../database/schema';
+import { desc } from 'drizzle-orm';
+
+/**
+ * DrizzleCommunityThreadRepository は PostgreSQL (Drizzle) を使用した掲示板スレッドのリポジトリ実装です。
+ * @responsibility: スレッドの一覧取得と新規作成を担当する。
+ */
+export class DrizzleCommunityThreadRepository implements CommunityThreadRepositoryPort {
+  constructor(private readonly db: DbType) {}
+
+  /**
+   * findAll は掲示板スレッドを新しい順で取得します。
+   */
+  async findAll(limit: number): Promise<CommunityThread[]> {
+    const rows = await this.db
+      .select()
+      .from(communityThreads)
+      .orderBy(desc(communityThreads.createdAt))
+      .limit(limit);
+
+    return rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      body: r.body,
+      category: r.category,
+      replyCount: r.replyCount,
+      createdAt: r.createdAt.toISOString(),
+    }));
+  }
+
+  /**
+   * create は新規スレッドを作成して返します。
+   */
+  async create(input: CreateCommunityThreadInput): Promise<CommunityThread> {
+    const [row] = await this.db
+      .insert(communityThreads)
+      .values({
+        title: input.title,
+        body: input.body,
+        category: input.category ?? 'General',
+      })
+      .returning();
+
+    return {
+      id: row.id,
+      title: row.title,
+      body: row.body,
+      category: row.category,
+      replyCount: row.replyCount,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+}

--- a/apps/backend/src/interface/controller/communityController.ts
+++ b/apps/backend/src/interface/controller/communityController.ts
@@ -2,9 +2,11 @@ import { Context } from 'hono';
 import { Bindings, AppVariables } from '../types';
 import { GetCommunityThreadsUseCase } from '../../application/use_case/getCommunityThreadsUseCase';
 import { CreateCommunityThreadUseCase } from '../../application/use_case/createCommunityThreadUseCase';
+import { CreateCommunityThreadInput } from '../../domain/entities/communityThread';
 
 /**
  * CommunityController は掲示板スレッドに関するリクエストを処理します。
+ * @responsibility 掲示板スレッドに関する HTTP リクエストのバリデーションとユースケースの実行を制御する。
  */
 export class CommunityController {
   /* c8 ignore next */
@@ -12,6 +14,7 @@ export class CommunityController {
 
   /**
    * スレッド一覧の取得
+   * @responsibility ユースケースを実行し、スレッド一覧を JSON 形式で返す。
    */
   static async getThreads(
     c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
@@ -29,18 +32,15 @@ export class CommunityController {
 
   /**
    * スレッドの新規作成
+   * @responsibility リクエストボディをバリデーションし、ユースケースを実行して新規スレッドを返す。
    */
   static async createThread(
     c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
   ) {
     try {
-      const body = c.req.valid('json' as never) as { title: string; body: string; category?: string };
+      const input = c.req.valid('json' as never) as CreateCommunityThreadInput;
       const useCase = new CreateCommunityThreadUseCase(c.get('communityThreadRepo'));
-      const thread = await useCase.execute({
-        title: body.title,
-        body: body.body,
-        category: body.category ?? 'General',
-      });
+      const thread = await useCase.execute(input);
       return c.json(thread, 201);
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/apps/backend/src/interface/controller/communityController.ts
+++ b/apps/backend/src/interface/controller/communityController.ts
@@ -1,0 +1,51 @@
+import { Context } from 'hono';
+import { Bindings, AppVariables } from '../types';
+import { GetCommunityThreadsUseCase } from '../../application/use_case/getCommunityThreadsUseCase';
+import { CreateCommunityThreadUseCase } from '../../application/use_case/createCommunityThreadUseCase';
+
+/**
+ * CommunityController は掲示板スレッドに関するリクエストを処理します。
+ */
+export class CommunityController {
+  /* c8 ignore next */
+  constructor() {}
+
+  /**
+   * スレッド一覧の取得
+   */
+  static async getThreads(
+    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
+  ) {
+    try {
+      const useCase = new GetCommunityThreadsUseCase(c.get('communityThreadRepo'));
+      const threads = await useCase.execute();
+      return c.json({ threads }, 200);
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error('[Community Threads Error]', error.message);
+      return c.json({ error: 'スレッド一覧の取得に失敗しました' }, 500);
+    }
+  }
+
+  /**
+   * スレッドの新規作成
+   */
+  static async createThread(
+    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
+  ) {
+    try {
+      const body = c.req.valid('json' as never) as { title: string; body: string; category?: string };
+      const useCase = new CreateCommunityThreadUseCase(c.get('communityThreadRepo'));
+      const thread = await useCase.execute({
+        title: body.title,
+        body: body.body,
+        category: body.category ?? 'General',
+      });
+      return c.json(thread, 201);
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error('[Community Thread Create Error]', error.message);
+      return c.json({ error: 'スレッドの作成に失敗しました' }, 500);
+    }
+  }
+}

--- a/apps/backend/src/interface/controller/test/communityController.test.ts
+++ b/apps/backend/src/interface/controller/test/communityController.test.ts
@@ -1,0 +1,140 @@
+import { expect, describe, it, mock, beforeEach } from 'bun:test';
+import { CommunityController } from '../communityController';
+import { createMockContext } from '../../test/testHelpers';
+import { AppVariables } from '../../types';
+import { CommunityThread } from '../../../domain/entities/communityThread';
+
+interface MockResponse {
+  body: Record<string, unknown> & {
+    threads?: CommunityThread[];
+    error?: string;
+    id?: string;
+    title?: string;
+  };
+  status: number;
+}
+
+const mockThread: CommunityThread = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前後のXAUUSDの値幅について',
+  body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+  category: 'Market Discussion',
+  replyCount: 12,
+  createdAt: '2026-04-01T12:00:00.000Z',
+};
+
+/**
+ * CommunityController Unit Tests
+ * @responsibility: 掲示板スレッドの一覧取得・作成APIの正常系・異常系を検証する。
+ */
+describe('CommunityController', () => {
+  it('クラスをインスタンス化できること', () => {
+    expect(new CommunityController()).toBeInstanceOf(CommunityController);
+  });
+
+  let mockRepos: Partial<AppVariables>;
+
+  beforeEach(() => {
+    mockRepos = {
+      communityThreadRepo: {
+        findAll: mock(() => Promise.resolve([mockThread])),
+        create: mock(() => Promise.resolve(mockThread)),
+      } as unknown as AppVariables['communityThreadRepo'],
+    };
+  });
+
+  // ==========================================
+  // getThreads
+  // ==========================================
+  describe('getThreads', () => {
+    it('スレッド一覧を取得して 200 を返すこと', async () => {
+      // ## Arrange ##
+      const c = createMockContext(mockRepos);
+
+      // ## Act ##
+      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(1);
+      expect(res.body.threads?.[0].id).toBe(mockThread.id);
+    });
+
+    it('リポジトリが空配列を返した場合、空の threads 配列と 200 を返すこと', async () => {
+      // ## Arrange ##
+      if (mockRepos.communityThreadRepo) {
+        mockRepos.communityThreadRepo.findAll = mock(() => Promise.resolve([]));
+      }
+      const c = createMockContext(mockRepos);
+
+      // ## Act ##
+      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(0);
+    });
+
+    it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
+      // ## Arrange ##
+      if (mockRepos.communityThreadRepo) {
+        mockRepos.communityThreadRepo.findAll = mock(() =>
+          Promise.reject(new Error('DB接続エラー')),
+        );
+      }
+      const c = createMockContext(mockRepos);
+
+      // ## Act ##
+      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('スレッド一覧の取得に失敗しました');
+    });
+  });
+
+  // ==========================================
+  // createThread
+  // ==========================================
+  describe('createThread', () => {
+    it('有効な入力でスレッドを作成して 201 を返すこと', async () => {
+      // ## Arrange ##
+      const body = {
+        title: 'CPI発表前後のXAUUSDの値幅について',
+        body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+        category: 'Market Discussion',
+      };
+      const c = createMockContext(mockRepos, {}, body as Record<string, string>);
+
+      // ## Act ##
+      const res = (await CommunityController.createThread(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe(mockThread.id);
+      expect(res.body.title).toBe(mockThread.title);
+    });
+
+    it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
+      // ## Arrange ##
+      if (mockRepos.communityThreadRepo) {
+        mockRepos.communityThreadRepo.create = mock(() =>
+          Promise.reject(new Error('INSERT失敗')),
+        );
+      }
+      const body = {
+        title: 'NFP後の戻りについて',
+        body: '本文です。',
+        category: 'General',
+      };
+      const c = createMockContext(mockRepos, {}, body as Record<string, string>);
+
+      // ## Act ##
+      const res = (await CommunityController.createThread(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('スレッドの作成に失敗しました');
+    });
+  });
+});

--- a/apps/backend/src/interface/middleware/diMiddleware.test.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.test.ts
@@ -14,7 +14,7 @@ describe("diMiddleware", () => {
     const middleware = diMiddleware();
     await middleware(c, next);
 
-    expect(set).toHaveBeenCalledTimes(5);
+    expect(set).toHaveBeenCalledTimes(6);
     expect(next).toHaveBeenCalled();
 
     // セットされたキーの確認
@@ -24,5 +24,6 @@ describe("diMiddleware", () => {
     expect(calledKeys).toContain("sessionRepo");
     expect(calledKeys).toContain("syncRepo");
     expect(calledKeys).toContain("batchRepo");
+    expect(calledKeys).toContain("communityThreadRepo");
   });
 });

--- a/apps/backend/src/interface/middleware/diMiddleware.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.ts
@@ -7,6 +7,7 @@ import { DrizzlePriceRepository } from '../../infrastructure/repository/drizzleP
 import { DrizzleZigZagRepository } from '../../infrastructure/repository/drizzleZigZagRepository';
 import { DrizzleSessionRepository } from '../../infrastructure/repository/drizzleSessionRepository';
 import { DrizzleBatchRepository } from '../../infrastructure/repository/drizzleBatchRepository';
+import { DrizzleCommunityThreadRepository } from '../../infrastructure/repository/drizzleCommunityThreadRepository';
 
 /**
  * diMiddleware は、リクエスト毎に必要な依存オブジェクトを Context に注入します。
@@ -23,6 +24,7 @@ export const diMiddleware = (): MiddlewareHandler => {
     c.set('sessionRepo', new DrizzleSessionRepository(db));
     c.set('syncRepo', new DrizzleSyncRepository(db));
     c.set('batchRepo', new DrizzleBatchRepository(db));
+    c.set('communityThreadRepo', new DrizzleCommunityThreadRepository(db));
 
     await next();
   };

--- a/apps/backend/src/interface/routes/openapi.ts
+++ b/apps/backend/src/interface/routes/openapi.ts
@@ -4,6 +4,7 @@ import { ZigZagPointSchema } from "../../domain/entities/zigzag";
 import { SessionVolatilitySchema } from "../../domain/entities/session";
 import { SyncStatusSchema } from "../../domain/entities/syncStatus";
 import { ReplayDataResponseSchema } from "../../domain/entities/replay";
+import { CommunityThreadSchema, CreateCommunityThreadInputSchema } from "../../domain/entities/communityThread";
 
 /**
  * Health Check ルート
@@ -227,6 +228,62 @@ export const syncDataRoute = createRoute({
     500: {
       description: "同期失敗",
     }
+  },
+});
+
+/**
+ * 掲示板スレッド一覧ルート
+ */
+export const communityThreadsRoute = createRoute({
+  method: "get",
+  path: "/api/v1/community/threads",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            threads: z.array(CommunityThreadSchema),
+          }),
+        },
+      },
+      description: "掲示板スレッド一覧を新しい順で取得します",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * 掲示板スレッド作成ルート
+ */
+export const createCommunityThreadRoute = createRoute({
+  method: "post",
+  path: "/api/v1/community/threads",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateCommunityThreadInputSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: CommunityThreadSchema,
+        },
+      },
+      description: "掲示板スレッドを作成して返します",
+    },
+    400: {
+      description: "バリデーションエラー",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
   },
 });
 

--- a/apps/backend/src/interface/types.ts
+++ b/apps/backend/src/interface/types.ts
@@ -4,6 +4,7 @@ import { ZigZagRepositoryPort } from '../application/port/zigzagRepositoryPort';
 import { SessionRepositoryPort } from '../application/port/sessionRepositoryPort';
 import { DrizzleBatchRepository } from '../infrastructure/repository/drizzleBatchRepository';
 import { AnalyticsServicePort } from '../application/port/analyticsServicePort';
+import { CommunityThreadRepositoryPort } from '../application/port/communityThreadRepositoryPort';
 
 /**
  * Bindings は 環境変数などの定義です。
@@ -24,4 +25,5 @@ export type AppVariables = {
   sessionRepo: SessionRepositoryPort;
   batchRepo: DrizzleBatchRepository;
   analyticsService: AnalyticsServicePort;
+  communityThreadRepo: CommunityThreadRepositoryPort;
 };

--- a/apps/frontend/src/app/community/loading.tsx
+++ b/apps/frontend/src/app/community/loading.tsx
@@ -1,0 +1,21 @@
+/**
+ * CommunityLoading は掲示板ページの読み込み状態を表示します。
+ * @responsibility 投稿一覧APIの応答待ち中にユーザーへ進行中であることを伝える。
+ */
+export default function CommunityLoading() {
+  return (
+    <section className="grid gap-8 rounded-[2rem] border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 lg:grid-cols-[0.8fr_1.2fr] lg:p-10">
+      <div className="space-y-5">
+        <div className="h-3 w-40 animate-pulse rounded bg-amber-100" />
+        <div className="h-24 max-w-md animate-pulse rounded-2xl bg-slate-100" />
+        <div className="h-20 max-w-lg animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+
+      <div className="space-y-3">
+        <div className="h-32 animate-pulse rounded-2xl bg-slate-100" />
+        <div className="h-32 animate-pulse rounded-2xl bg-slate-100" />
+        <div className="h-32 animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/app/community/page.tsx
+++ b/apps/frontend/src/app/community/page.tsx
@@ -1,33 +1,33 @@
 import type { Metadata } from "next";
+import { getCommunityThreads } from "@/features/community/api/getCommunityThreads";
+import { CommunityThreadList } from "@/features/community/components/CommunityThreadList";
+import type { CommunityThread } from "@/lib/api/client";
 
 export const metadata: Metadata = {
   title: "掲示板",
-  description: "fanda-devのXAUUSD分析・GOLD分析に関するユーザー掲示板のモックページです。",
+  description: "fanda-devのXAUUSD分析・GOLD分析に関するユーザー掲示板です。",
 };
 
-const discussionTopics = [
-  {
-    title: "CPI発表前後のXAUUSDの値幅をどう見ていますか？",
-    meta: "Market Discussion / 12 replies",
-    excerpt: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったので、今回もセッション別に見たいです。",
-  },
-  {
-    title: "雇用統計の日はロンドン時間からボラが出やすい？",
-    meta: "Session Notes / 8 replies",
-    excerpt: "発表前のポジション調整っぽい動きがあるか、過去イベントのリプレイで比較したいです。",
-  },
-  {
-    title: "GOLD分析でよく見る指標を共有するスレ",
-    meta: "Research Setup / 5 replies",
-    excerpt: "CPI、NFP、FOMC、PCEあたりを優先して、反応の違いをメモしていく想定です。",
-  },
-];
+type CommunityThreadsResult =
+  | { status: "success"; threads: CommunityThread[] }
+  | { status: "error" };
+
+async function resolveCommunityThreads(): Promise<CommunityThreadsResult> {
+  try {
+    const { threads } = await getCommunityThreads();
+    return { status: "success", threads };
+  } catch {
+    return { status: "error" };
+  }
+}
 
 /**
- * CommunityPage はユーザー掲示板のモックページを表示するコンポーネントです。
- * @responsibility XAUUSD分析に関するユーザー間の情報共有の場（モック）を提供する。
+ * CommunityPage はユーザー掲示板ページを表示するコンポーネントです。
+ * @responsibility XAUUSD分析に関する投稿一覧をAPIから取得して表示する。
  */
-export default function CommunityPage() {
+export default async function CommunityPage() {
+  const result = await resolveCommunityThreads();
+
   return (
         <section className="grid gap-8 rounded-[2rem] border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 lg:grid-cols-[0.8fr_1.2fr] lg:p-10">
           <div className="space-y-5">
@@ -38,21 +38,20 @@ export default function CommunityPage() {
               XAUUSD分析の気づきを残す掲示板。
             </h2>
             <p className="text-base leading-8 text-slate-600">
-              まだモックですが、指標前後の値動き、セッション別の荒れ方、GOLD分析の観点をユーザー同士で共有する場所として用意しています。
+              指標前後の値動き、セッション別の荒れ方、GOLD分析の観点をユーザー同士で共有する場所です。
             </p>
           </div>
 
-          <div className="space-y-3">
-            {discussionTopics.map((topic) => (
-              <article key={topic.title} className="rounded-2xl border border-slate-200 bg-[#fbfaf7] p-5">
-                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                  {topic.meta}
-                </p>
-                <h3 className="text-lg font-semibold text-slate-950">{topic.title}</h3>
-                <p className="mt-3 text-sm leading-6 text-slate-600">{topic.excerpt}</p>
-              </article>
-            ))}
-          </div>
+          {result.status === "success" ? (
+            <CommunityThreadList threads={result.threads} />
+          ) : (
+            <div className="rounded-2xl border border-red-200 bg-red-50 p-6">
+              <h3 className="text-lg font-semibold text-red-950">掲示板投稿を取得できませんでした</h3>
+              <p className="mt-3 text-sm leading-6 text-red-800">
+                時間をおいて再度お試しください。APIが未準備の場合は、投稿一覧APIの実装後に表示されます。
+              </p>
+            </div>
+          )}
         </section>
   );
 }

--- a/apps/frontend/src/features/community/api/getCommunityThreads.test.ts
+++ b/apps/frontend/src/features/community/api/getCommunityThreads.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { getCommunityThreads } from "./getCommunityThreads";
+
+let requestHeaders = new Headers();
+mock.module("next/headers", () => ({
+  headers: () => Promise.resolve(requestHeaders),
+}));
+
+const getMock = mock();
+mock.module("@/lib/api/client", () => ({
+  apiClient: {
+    api: {
+      v1: {
+        community: {
+          threads: {
+            $get: getMock,
+          },
+        },
+      },
+    },
+  },
+}));
+
+describe("getCommunityThreads", () => {
+  beforeEach(() => {
+    getMock.mockClear();
+    requestHeaders = new Headers();
+  });
+
+  it("正常に掲示板投稿一覧を取得できた場合、JSONデータを返すこと", async () => {
+    /* ## Arrange ## */
+    const mockResponse = {
+      threads: [
+        {
+          id: "thread-1",
+          title: "CPI発表前後のXAUUSDの値幅をどう見ていますか？",
+          category: "Market Discussion",
+          excerpt: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
+          replyCount: 12,
+          createdAt: "2026-04-01T12:00:00Z",
+        },
+      ],
+    };
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    /* ## Act ## */
+    const result = await getCommunityThreads();
+
+    /* ## Assert ## */
+    expect(getMock).toHaveBeenCalled();
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("x-test-scenario ヘッダーがある場合、API呼び出しへ転送すること", async () => {
+    /* ## Arrange ## */
+    requestHeaders = new Headers({ "x-test-scenario": "empty" });
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ threads: [] }),
+    });
+
+    /* ## Act ## */
+    await getCommunityThreads();
+
+    /* ## Assert ## */
+    const init = getMock.mock.calls[0][1].init;
+    expect(init.headers["x-test-scenario"]).toBe("empty");
+  });
+
+  it("API呼び出しが失敗した場合、Errorをスローすること", async () => {
+    /* ## Arrange ## */
+    getMock.mockResolvedValue({
+      ok: false,
+    });
+
+    /* ## Act & Assert ## */
+    expect(getCommunityThreads()).rejects.toThrow("掲示板投稿の取得に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/community/api/getCommunityThreads.ts
+++ b/apps/frontend/src/features/community/api/getCommunityThreads.ts
@@ -1,0 +1,29 @@
+import { headers } from "next/headers";
+import { apiClient } from "@/lib/api/client";
+
+/**
+ * getCommunityThreads は掲示板スレッド一覧を取得します。
+ * @responsibility バックエンドAPIを呼び出し、Communityページで表示する投稿一覧を返却する。
+ */
+export async function getCommunityThreads() {
+  const headerList = await headers();
+  const scenario = headerList.get("x-test-scenario");
+  const initHeaders: HeadersInit = {};
+  if (scenario) {
+    initHeaders["x-test-scenario"] = scenario;
+  }
+
+  const res = await apiClient.api.v1.community.threads.$get(undefined, {
+    init: {
+      cache: "no-store",
+      headers: initHeaders,
+      signal: AbortSignal.timeout(5000),
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error("掲示板投稿の取得に失敗しました");
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/community/components/CommunityThreadList.test.tsx
+++ b/apps/frontend/src/features/community/components/CommunityThreadList.test.tsx
@@ -8,7 +8,7 @@ const threads: CommunityThread[] = [
     id: "thread-1",
     title: "CPI発表前後のXAUUSDの値幅をどう見ていますか？",
     category: "Market Discussion",
-    excerpt: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
+    body: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
     replyCount: 12,
     createdAt: "2026-04-01T12:00:00Z",
   },

--- a/apps/frontend/src/features/community/components/CommunityThreadList.test.tsx
+++ b/apps/frontend/src/features/community/components/CommunityThreadList.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { CommunityThreadList } from "./CommunityThreadList";
+import type { CommunityThread } from "@/lib/api/client";
+
+const threads: CommunityThread[] = [
+  {
+    id: "thread-1",
+    title: "CPI発表前後のXAUUSDの値幅をどう見ていますか？",
+    category: "Market Discussion",
+    excerpt: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
+    replyCount: 12,
+    createdAt: "2026-04-01T12:00:00Z",
+  },
+];
+
+describe("CommunityThreadList", () => {
+  it("投稿一覧がある場合にスレッド情報を表示すること", () => {
+    /* ## Arrange ## */
+    render(<CommunityThreadList threads={threads} />);
+
+    /* ## Act ## */
+    const title = screen.getByText("CPI発表前後のXAUUSDの値幅をどう見ていますか？");
+
+    /* ## Assert ## */
+    expect(title).toBeDefined();
+    expect(screen.getByText("Market Discussion / 12 replies")).toBeDefined();
+    expect(screen.getByText("前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。")).toBeDefined();
+  });
+
+  it("投稿一覧が空の場合に空状態の案内を表示すること", () => {
+    /* ## Arrange ## */
+    render(<CommunityThreadList threads={[]} />);
+
+    /* ## Act ## */
+    const emptyTitle = screen.getByText("まだ投稿がありません");
+
+    /* ## Assert ## */
+    expect(emptyTitle).toBeDefined();
+    expect(screen.getByText("XAUUSD分析やGOLD分析の気づきが投稿されると、ここに一覧表示されます。")).toBeDefined();
+  });
+});

--- a/apps/frontend/src/features/community/components/CommunityThreadList.tsx
+++ b/apps/frontend/src/features/community/components/CommunityThreadList.tsx
@@ -28,7 +28,7 @@ export function CommunityThreadList({ threads }: CommunityThreadListProps) {
             {thread.category} / {thread.replyCount} replies
           </p>
           <h3 className="text-lg font-semibold text-slate-950">{thread.title}</h3>
-          <p className="mt-3 text-sm leading-6 text-slate-600">{thread.excerpt}</p>
+          <p className="mt-3 text-sm leading-6 text-slate-600">{thread.body}</p>
           <time className="mt-4 block text-xs font-medium text-slate-400" dateTime={thread.createdAt}>
             {new Intl.DateTimeFormat("ja-JP", {
               dateStyle: "medium",

--- a/apps/frontend/src/features/community/components/CommunityThreadList.tsx
+++ b/apps/frontend/src/features/community/components/CommunityThreadList.tsx
@@ -1,0 +1,43 @@
+import type { CommunityThread } from "@/lib/api/client";
+
+type CommunityThreadListProps = {
+  threads: CommunityThread[];
+};
+
+/**
+ * CommunityThreadList は掲示板スレッド一覧を表示するコンポーネントです。
+ * @responsibility APIから取得した投稿一覧・空状態をユーザーに分かりやすく表示する。
+ */
+export function CommunityThreadList({ threads }: CommunityThreadListProps) {
+  if (threads.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-[#fbfaf7] p-6 text-center">
+        <h3 className="text-lg font-semibold text-slate-950">まだ投稿がありません</h3>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          XAUUSD分析やGOLD分析の気づきが投稿されると、ここに一覧表示されます。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {threads.map((thread) => (
+        <article key={thread.id} className="rounded-2xl border border-slate-200 bg-[#fbfaf7] p-5">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            {thread.category} / {thread.replyCount} replies
+          </p>
+          <h3 className="text-lg font-semibold text-slate-950">{thread.title}</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-600">{thread.excerpt}</p>
+          <time className="mt-4 block text-xs font-medium text-slate-400" dateTime={thread.createdAt}>
+            {new Intl.DateTimeFormat("ja-JP", {
+              dateStyle: "medium",
+              timeStyle: "short",
+              timeZone: "Asia/Tokyo",
+            }).format(new Date(thread.createdAt))}
+          </time>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -11,6 +11,9 @@ export type AppClient = {
         replay: { $get: (args: { query: { event: string } }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ReplayDataResponse> }> };
         sessions: { $get: (args: { query: { limit: string } }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<SessionsResponse> }> };
       }
+      community: {
+        threads: { $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<CommunityThreadsResponse> }> };
+      }
     }
   }
 };
@@ -58,6 +61,19 @@ export type SessionsResponse = {
 
 export type IndicatorsResponse = {
   indicators: string[];
+};
+
+export type CommunityThread = {
+  id: string;
+  title: string;
+  category: string;
+  excerpt: string;
+  replyCount: number;
+  createdAt: string;
+};
+
+export type CommunityThreadsResponse = {
+  threads: CommunityThread[];
 };
 
 export type Candle = {

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -67,7 +67,7 @@ export type CommunityThread = {
   id: string;
   title: string;
   category: string;
-  excerpt: string;
+  body: string;
   replyCount: number;
   createdAt: string;
 };

--- a/apps/frontend/src/test/handlers.test.ts
+++ b/apps/frontend/src/test/handlers.test.ts
@@ -65,6 +65,36 @@ describe("MSW abnormal scenarios", () => {
     expect(body.previousEvent.eventsLinked).toBe("CPI");
   });
 
+  it("掲示板投稿一覧APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/community/threads");
+    const body = await res.json() as { threads: Array<{ title: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.threads[0].title).toBe("CPI発表前後のXAUUSDの値幅をどう見ていますか？");
+  });
+
+  it("x-test-scenario=empty で空の掲示板投稿一覧を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/community/threads", {
+      headers: {
+        "x-test-scenario": "empty",
+      },
+    });
+    const body = await res.json() as { threads: unknown[] };
+
+    expect(res.status).toBe(200);
+    expect(body.threads).toEqual([]);
+  });
+
+  it("x-test-scenario=error で掲示板投稿一覧APIの500応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/community/threads", {
+      headers: {
+        "x-test-scenario": "error",
+      },
+    });
+
+    expect(res.status).toBe(500);
+  });
+
   it("未ログイン時の認証セッションAPIは null を返すこと", async () => {
     const res = await fetch("http://localhost:3000/api/auth/get-session");
     const body = await res.json();

--- a/apps/frontend/src/test/handlers.ts
+++ b/apps/frontend/src/test/handlers.ts
@@ -101,7 +101,7 @@ export const handlers = [
           id: 'thread-1',
           title: 'CPI発表前後のXAUUSDの値幅をどう見ていますか？',
           category: 'Market Discussion',
-          excerpt: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+          body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
           replyCount: 12,
           createdAt: '2026-04-01T12:00:00Z',
         },

--- a/apps/frontend/src/test/handlers.ts
+++ b/apps/frontend/src/test/handlers.ts
@@ -84,6 +84,31 @@ export const handlers = [
     });
   }),
 
+  /* 掲示板投稿一覧 */
+  http.get(`${baseUrl}/api/v1/community/threads`, ({ request }) => {
+    const scenario = request.headers.get('x-test-scenario');
+
+    if (scenario === 'error') {
+      return new HttpResponse(null, { status: 500 });
+    }
+    if (scenario === 'empty') {
+      return HttpResponse.json({ threads: [] });
+    }
+
+    return HttpResponse.json({
+      threads: [
+        {
+          id: 'thread-1',
+          title: 'CPI発表前後のXAUUSDの値幅をどう見ていますか？',
+          category: 'Market Discussion',
+          excerpt: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+          replyCount: 12,
+          createdAt: '2026-04-01T12:00:00Z',
+        },
+      ],
+    });
+  }),
+
   /* 認証 (better-auth) - セッション取得 */
   http.get(`${baseUrl}/api/auth/get-session`, ({ request }) => {
     const cookie = request.headers.get('cookie');


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #28
Closes #29

# Todo

- [x] **[BE] #28: 掲示板の投稿一覧・作成APIを実装する**
  - [x] `communityThreads` テーブルを DB スキーマに追加
  - [x] `CommunityThread` ドメインエンティティと Zod スキーマを定義（タイトル・本文・カテゴリ・作成日時）
  - [x] `CommunityThreadRepositoryPort` インターフェースを定義
  - [x] `GetCommunityThreadsUseCase` / `CreateCommunityThreadUseCase` を実装
  - [x] `DrizzleCommunityThreadRepository` を実装（一覧取得・新規作成）
  - [x] OpenAPI ルート `GET /api/v1/community/threads` / `POST /api/v1/community/threads` を追加
  - [x] `CommunityController` を実装（正常系・異常系ハンドリング）
  - [x] `diMiddleware` と `AppVariables` に `communityThreadRepo` を追加
  - [x] 各層のユニットテスト（UseCase 2 × 、Controller 5 件）を追加

- [x] **[FE] #29: 掲示板ページをAPIデータ表示に切り替える**
  - [x] `getCommunityThreads` API クライアント関数を実装（`x-test-scenario` 対応）
  - [x] `CommunityThreadList` コンポーネントを作成（データあり・空状態）
  - [x] `community/page.tsx` を実データ取得に切り替え（success / error ブランチ）
  - [x] `community/loading.tsx` でスケルトン UI を追加
  - [x] MSW ハンドラーに `/api/v1/community/threads` を追加（正常・空・500 シナリオ）
  - [x] 各層のユニットテスト（API 関数 3 件、コンポーネント 2 件）を追加

# How to check (動作確認の手順)

```zsh
# バックエンドのテストを実行
cd apps/backend && bun test

# フロントエンドのテストを実行
cd apps/frontend && bun test

# 開発サーバー起動 (BE)
cd apps/backend && bun run dev

# 開発サーバー起動 (FE)
cd apps/frontend && bun run dev

# 掲示板ページを確認
open http://localhost:3001/community

# APIを直接確認
curl http://localhost:3000/api/v1/community/threads
```

**DB マイグレーション（本番適用時）:**
```zsh
cd apps/backend
bun run db:generate   # マイグレーションファイルを生成
bun run db:migrate    # マイグレーションを実行
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

**バックエンドテスト結果（86 pass / 0 fail）:**
```
86 pass
0 fail
186 expect() calls
Ran 86 tests across 27 files.
```

**フロントエンドテスト結果（45 pass / 0 fail）:**
```
45 pass
0 fail
73 expect() calls
Ran 45 tests across 11 files.
```

**Lint:** 両方クリア（エラーなし）

</details>

# Related Links

- Issue #28: [BE] 掲示板の投稿一覧・作成APIを実装する
- Issue #29: [FE] 掲示板ページをAPIデータ表示に切り替える
- アーキテクチャ: DDD (Domain / Application / Infrastructure / Interface の 4 層)

Made with [Cursor](https://cursor.com)