### PR TITLE
ci: pass frontend API URL into production build

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build
         run: cd apps/frontend && bun run build
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
# Issue (対象のIssue)

N/A

# Todo

- [x] GitHub Repository Variable `NEXT_PUBLIC_API_URL` を production API URL として追加
- [x] Frontend CD の build step に `${{ vars.NEXT_PUBLIC_API_URL }}` を渡す

# How to check (動作確認の手順)

```zsh
bun run lint:frontend
bun run lint:backend
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

Commit hook で以下が成功しました。

```zsh
bun run lint:frontend && bun run lint:backend
```

</details>

# Related Links

- Production API URL: `https://api.fanda-dev.com`

Made with [Cursor](https://cursor.com)