### PR TITLE
[CI/CD] fix: pass backend image explicitly to docker-compose

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -59,9 +59,10 @@ jobs:
               gcloud auth configure-docker --quiet &&
               export BACKEND_IMAGE=${{ env.GCR_IMAGE }}:${{ github.sha }} &&
               export BACKEND_BASE_URL=${{ env.BACKEND_BASE_URL }} &&
-              sudo -E docker-compose pull backend &&
-              sudo -E docker-compose run --rm backend bun run db:migrate &&
-              sudo -E docker-compose up -d --force-recreate backend &&
+              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose config | sed -n '/backend:/,/^[^ ]/p' &&
+              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose pull backend &&
+              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose run --rm backend bun run src/infrastructure/database/migrate.ts &&
+              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose up -d --force-recreate backend &&
               for url in \"\$BACKEND_BASE_URL/health\" \"\$BACKEND_BASE_URL/api/auth/get-session\"; do
                 for attempt in 1 2 3 4 5; do
                   curl -fsS \"\$url\" && break


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #63

# Todo

- [x] Pass `BACKEND_IMAGE` to every `docker-compose` invocation with `sudo env`
- [x] Log the resolved backend service config before pulling/running
- [x] Run the runtime migration script directly instead of relying on package scripts in a stale image

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- `bun run lint:all`: pass
- `bun run test:all`: pass

</details>

# Related Links

- Issue: #63
- Follows failed Backend CD run where compose still executed `$ drizzle-kit migrate` after PR #61

Made with [Cursor](https://cursor.com)