### PR TITLE
[CI/CD] fix: sync GCE deploy repo before docker-compose

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -56,6 +56,10 @@ jobs:
             --tunnel-through-iap \
             --command="
               cd ~/gold-bunseki-web &&
+              git fetch origin main &&
+              git reset --hard ${{ github.sha }} &&
+              test \"\$(git rev-parse HEAD)\" = \"${{ github.sha }}\" &&
+              git rev-parse HEAD &&
               gcloud auth configure-docker --quiet &&
               export BACKEND_IMAGE=${{ env.GCR_IMAGE }}:${{ github.sha }} &&
               export BACKEND_BASE_URL=${{ env.BACKEND_BASE_URL }} &&


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #66

# Todo

- [x] Fetch `origin/main` on the GCE deploy host before running docker-compose
- [x] Reset `~/gold-bunseki-web` to the workflow `${{ github.sha }}`
- [x] Assert the remote deploy directory HEAD matches the workflow SHA
- [x] Keep existing compose image/config logging and runtime migration execution

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- `bun run lint:all`: pass
- `bun run test:all`: pass

</details>

# Related Links

- Issue: #66
- Root cause: GCE deploy directory was stale, so docker-compose still used old `build.context` and old app files.

Made with [Cursor](https://cursor.com)