### PR TITLE
[CI/CD] fix: authenticate sudo docker to GCR before backend pull

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -60,7 +60,8 @@ jobs:
               git reset --hard ${{ github.sha }} &&
               test \"\$(git rev-parse HEAD)\" = \"${{ github.sha }}\" &&
               git rev-parse HEAD &&
-              gcloud auth configure-docker --quiet &&
+              gcloud auth configure-docker gcr.io --quiet &&
+              gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://gcr.io &&
               export BACKEND_IMAGE=${{ env.GCR_IMAGE }}:${{ github.sha }} &&
               export BACKEND_BASE_URL=${{ env.BACKEND_BASE_URL }} &&
               sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose config | sed -n '/backend:/,/^[^ ]/p' &&


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #69

# Todo

- [x] Scope `gcloud auth configure-docker` to `gcr.io`
- [x] Authenticate root Docker with a GCR access token before `sudo docker-compose pull`

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- `bun run lint:all`: pass
- `bun run test:all`: pass

</details>

# Related Links

- Issue: #69
- Root cause: Docker auth was configured for the SSH user, while compose commands run Docker through `sudo`.

Made with [Cursor](https://cursor.com)