### PR TITLE
[CI/CD] fix: avoid DB recreate and wait for backend health

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -67,11 +67,15 @@ jobs:
               sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose config | sed -n '/backend:/,/^[^ ]/p' &&
               sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose pull backend &&
               sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose run --rm backend bun run src/infrastructure/database/migrate.ts &&
-              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose up -d --force-recreate backend &&
+              sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose up -d --no-deps --force-recreate backend &&
               for url in \"\$BACKEND_BASE_URL/health\" \"\$BACKEND_BASE_URL/api/auth/get-session\"; do
-                for attempt in 1 2 3 4 5; do
+                for attempt in \$(seq 1 30); do
                   curl -fsS \"\$url\" && break
-                  if [ \"\$attempt\" = \"5\" ]; then exit 1; fi
+                  if [ \"\$attempt\" = \"30\" ]; then
+                    sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose ps
+                    sudo env BACKEND_IMAGE=\"\$BACKEND_IMAGE\" docker-compose logs --tail=80 backend
+                    exit 1
+                  fi
                   sleep 2
                 done
               done


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #72

# Todo

- [x] Add `--no-deps` so backend deploy does not recreate the PostgreSQL container
- [x] Extend post-deploy health check retries from 10s to 60s
- [x] Print compose status and backend logs if health checks still fail

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- `bun run lint:all`: pass
- `bun run test:all`: pass

</details>

# Related Links

- Issue: #72
- Follows Backend CD run that reached migration success but failed on temporary nginx 502 after container recreation.

Made with [Cursor](https://cursor.com)