### PR TITLE
[BE] AppContainerで掲示板APIの依存生成とルート登録を整理する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,24 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-04 - PR #82 Geminiレビュー対応
+
+- **達成したタスク**:
+  - PR #82 の Gemini Code Assist コメント3件を確認し、全て対応。
+  - `freezeAppContainer` を追加し、グローバル `appContainer` の top-level / repositories / useCases / useCases.community を `Object.freeze` で保護。
+  - CommunityController の独自 `console.error` / catch を削除し、例外を `handleAppError` に委譲する設計へ変更。
+  - `diMiddleware` から不要になった `communityThreadRepo` の Context 注入を削除し、`AppVariables` 型定義からも削除。
+  - PR本文のエビデンスを最新結果（2026-05-04 10:15 JST）へ更新し、各レビューコメントへ対応済み返信を追加。
+
+- **検証結果**:
+  - targeted backend tests: 18 pass / 0 fail
+  - `cd apps/backend && bunx tsc --noEmit`: pass
+  - `bun run test:all`: frontend 45 pass / backend 91 pass
+  - `bun run lint:all`: pass
+
+- **次回への申し送り事項**:
+  - PR #82 はレビュー対応済み。追加コメントがなければマージ可能。
+
 ### 2026-05-03 - Issue #81 AppContainer導入と掲示板ルート分離PR
 
 - **達成したタスク**:

--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,28 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-03 - Issue #81 AppContainer導入と掲示板ルート分離PR
+
+- **達成したタスク**:
+  - Issue #81 `[BE] AppContainerで掲示板APIの依存生成とルート登録を整理する` を作成。
+  - `refactor/issue-81-app-container-community` ブランチを `develop` から作成。
+  - `apps/backend/src/app/container.ts` を追加し、Repository / 掲示板 UseCase の生成を AppContainer に集約。
+  - `apps/backend/src/app/createApp.ts` を追加し、Hono アプリの組み立てを `createApp(container, options)` として切り出し、テストで mock container を注入可能にした。
+  - `CommunityController` を static class から `createCommunityController(container)` の handler factory へ変更。
+  - 掲示板ルート登録を `apps/backend/src/interface/routes/communityRoutes.ts` に分離。
+  - `index.ts` を startup env validation / app生成 / Bun.serve export の起動責務へ縮小。
+  - PR #82 `https://github.com/somadevfat/gold-bunseki-web/pull/82` を `develop` 向けに作成。
+
+- **検証結果**:
+  - `bun test src/app/container.test.ts src/interface/routes/test/apiIntegration.test.ts src/interface/controller/test/communityController.test.ts src/securityMiddleware.test.ts`: 16 pass / 0 fail
+  - `cd apps/backend && bunx tsc --noEmit`: pass
+  - `bun run test:all`: frontend 45 pass / backend 90 pass
+  - `bun run lint:all`: pass
+
+- **次回への申し送り事項**:
+  - PR #82 マージ後、同じパターンで Market / Sync routes/controller の依存生成と route 登録を段階的に移行できる。
+  - 未追跡の `.agents/skills/self-implement/` と `docs/archives/auth_strategy_zenn.md` は今回PRに含めていない。
+
 ### 2026-05-02 - CORS Origin マージ修正 Issue #79 / PR #80
 
 - **達成したタスク**:

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
+import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
+import { createAppContainer } from './container';
+import { createMockDrizzle } from '../interface/test/testHelpers';
+
+describe('createAppContainer', () => {
+  it('Repository と掲示板 UseCase を一箇所で生成して配線すること', () => {
+    const container = createAppContainer(createMockDrizzle());
+
+    expect(container.repositories.communityThreadRepo).toBeDefined();
+    expect(container.repositories.priceRepo).toBeDefined();
+    expect(container.repositories.syncRepo).toBeDefined();
+    expect(container.useCases.community.getThreads).toBeInstanceOf(GetCommunityThreadsUseCase);
+    expect(container.useCases.community.createThread).toBeInstanceOf(CreateCommunityThreadUseCase);
+  });
+});

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
 import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
-import { createAppContainer } from './container';
+import { createAppContainer, freezeAppContainer } from './container';
 import { createMockDrizzle } from '../interface/test/testHelpers';
 
 describe('createAppContainer', () => {
@@ -13,5 +13,14 @@ describe('createAppContainer', () => {
     expect(container.repositories.syncRepo).toBeDefined();
     expect(container.useCases.community.getThreads).toBeInstanceOf(GetCommunityThreadsUseCase);
     expect(container.useCases.community.createThread).toBeInstanceOf(CreateCommunityThreadUseCase);
+  });
+
+  it('グローバル利用するContainerの依存配線をfreezeできること', () => {
+    const container = freezeAppContainer(createAppContainer(createMockDrizzle()));
+
+    expect(Object.isFrozen(container)).toBe(true);
+    expect(Object.isFrozen(container.repositories)).toBe(true);
+    expect(Object.isFrozen(container.useCases)).toBe(true);
+    expect(Object.isFrozen(container.useCases.community)).toBe(true);
   });
 });

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -35,4 +35,16 @@ export function createAppContainer(database: DbType = db) {
 
 export type AppContainer = ReturnType<typeof createAppContainer>;
 
-export const appContainer = createAppContainer();
+/**
+ * freezeAppContainer はグローバルContainerの依存差し替えを防ぎます。
+ * @responsibility アプリ実行中に依存配線が誤って変更されないようにする。
+ */
+export function freezeAppContainer(container: AppContainer): AppContainer {
+  Object.freeze(container.repositories);
+  Object.freeze(container.useCases.community);
+  Object.freeze(container.useCases);
+
+  return Object.freeze(container);
+}
+
+export const appContainer = freezeAppContainer(createAppContainer());

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -1,0 +1,38 @@
+import { GetCommunityThreadsUseCase } from "../application/use_case/getCommunityThreadsUseCase";
+import { CreateCommunityThreadUseCase } from "../application/use_case/createCommunityThreadUseCase";
+import { db, DbType } from "../infrastructure/database/db";
+import { DrizzleBatchRepository } from "../infrastructure/repository/drizzleBatchRepository";
+import { DrizzleCommunityThreadRepository } from "../infrastructure/repository/drizzleCommunityThreadRepository";
+import { DrizzlePriceRepository } from "../infrastructure/repository/drizzlePriceRepository";
+import { DrizzleSessionRepository } from "../infrastructure/repository/drizzleSessionRepository";
+import { DrizzleSyncRepository } from "../infrastructure/repository/drizzleSyncRepository";
+import { DrizzleZigZagRepository } from "../infrastructure/repository/drizzleZigZagRepository";
+
+/**
+ * createAppContainer はアプリケーション全体の依存関係を生成して配線します。
+ * @responsibility Repository / UseCase のインスタンス生成を一箇所に集約する。
+ */
+export function createAppContainer(database: DbType = db) {
+  const communityThreadRepo = new DrizzleCommunityThreadRepository(database);
+
+  return {
+    repositories: {
+      priceRepo: new DrizzlePriceRepository(database),
+      zigzagRepo: new DrizzleZigZagRepository(database),
+      sessionRepo: new DrizzleSessionRepository(database),
+      syncRepo: new DrizzleSyncRepository(database),
+      batchRepo: new DrizzleBatchRepository(database),
+      communityThreadRepo,
+    },
+    useCases: {
+      community: {
+        getThreads: new GetCommunityThreadsUseCase(communityThreadRepo),
+        createThread: new CreateCommunityThreadUseCase(communityThreadRepo),
+      },
+    },
+  };
+}
+
+export type AppContainer = ReturnType<typeof createAppContainer>;
+
+export const appContainer = createAppContainer();

--- a/apps/backend/src/app/createApp.ts
+++ b/apps/backend/src/app/createApp.ts
@@ -1,0 +1,102 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { swaggerUI } from "@hono/swagger-ui";
+import * as routes from "../interface/routes/openapi";
+import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
+import { auth } from "../infrastructure/auth/auth";
+import { getAllowedOrigins } from "../infrastructure/security/origins";
+import { AppContainer } from "./container";
+
+// Middleware / Config
+import { diMiddleware } from "../interface/middleware/diMiddleware";
+import { handleAppError, handleNotFound } from "../interface/http/errorResponse";
+import { requestIdMiddleware } from "../interface/middleware/requestIdMiddleware";
+import { structuredLogger } from "../interface/middleware/structuredLogger";
+import { syncBearerAuth } from "../interface/middleware/syncBearerAuth";
+import { Bindings, AppVariables } from "../interface/types";
+import { registerCommunityRoutes } from "../interface/routes/communityRoutes";
+
+// Controllers
+import { MarketController } from "../interface/controller/marketController";
+import { SyncController } from "../interface/controller/syncController";
+
+const defaultAllowedOrigins = getAllowedOrigins();
+
+/**
+ * resolveCorsOrigin はリクエスト Origin が許可済みかを判定します。
+ * @responsibility 未知の Origin に CORS 許可ヘッダーを返さない fail-closed な制御を行う。
+ */
+export function resolveCorsOrigin(
+  origin: string | undefined,
+  allowedOrigins = defaultAllowedOrigins,
+): string | undefined {
+  return origin && allowedOrigins.includes(origin) ? origin : undefined;
+}
+
+type CreateAppOptions = {
+  apiToken: string;
+  allowedOrigins?: string[];
+};
+
+/**
+ * createApp は Hono アプリケーションを組み立てます。
+ * @responsibility middleware、認証、OpenAPI、feature route を組み合わせて app を生成する。
+ */
+export function createApp(
+  container: AppContainer,
+  options: CreateAppOptions,
+) {
+  const app = new OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>();
+  const allowedOrigins = options.allowedOrigins ?? defaultAllowedOrigins;
+
+  app.use("*", secureHeaders());
+  app.use("*", requestIdMiddleware());
+  app.use("*", structuredLogger());
+
+  app.use(
+    "*",
+    cors({
+      origin: (origin) => resolveCorsOrigin(origin, allowedOrigins),
+      allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowHeaders: ["Content-Type", "Authorization", "Accept"],
+      credentials: true,
+    }),
+  );
+
+  app.use("*", diMiddleware(container));
+  app.use("/api/v1/sync/*", syncBearerAuth(options.apiToken));
+
+  // Auth 関連 (better-auth)
+  app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+
+  app.doc("/doc", {
+    openapi: "3.0.0",
+    info: {
+      version: "1.0.0",
+      title: "Gold Volatility Bunseki API",
+      description: "Goldボラティリティ分析ツールのバックエンドAPI",
+    },
+  });
+  app.get("/swagger", swaggerUI({ url: "/doc" }));
+
+  app.openapi(routes.healthRoute, (c) =>
+    c.json({ status: "ok", server: "Hono/Bun" }),
+  );
+
+  app.openapi(routes.syncStatusRoute, SyncController.getSyncStatus);
+  app.openapi(routes.syncDataRoute, SyncController.receiveSyncData);
+  app.openapi(routes.syncSeedRoute, SyncController.receiveSeedData);
+
+  app.openapi(routes.latestPriceRoute, MarketController.getLatestPrice);
+  app.openapi(routes.calculateZigZagRoute, MarketController.calculateZigZag);
+  app.openapi(routes.marketSessionsRoute, MarketController.getRecentSessions);
+  app.openapi(routes.eventReplayRoute, MarketController.getEventReplay);
+  app.openapi(routes.marketIndicatorsRoute, MarketController.getIndicators);
+
+  registerCommunityRoutes(app, container);
+
+  app.notFound(handleNotFound);
+  app.onError(handleAppError);
+
+  return app;
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,62 +1,10 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
-import { swaggerUI } from "@hono/swagger-ui";
-import * as routes from "./interface/routes/openapi";
-import { cors } from "hono/cors";
-import { secureHeaders } from "hono/secure-headers";
-import { auth } from "./infrastructure/auth/auth";
-import { getAllowedOrigins } from "./infrastructure/security/origins";
-
-// Middleware / Config
-import { diMiddleware } from "./interface/middleware/diMiddleware";
-import { handleAppError, handleNotFound } from "./interface/http/errorResponse";
-import { requestIdMiddleware } from "./interface/middleware/requestIdMiddleware";
-import { structuredLogger } from "./interface/middleware/structuredLogger";
-import { syncBearerAuth } from "./interface/middleware/syncBearerAuth";
-import { Bindings, AppVariables } from "./interface/types";
-
-// Controllers
-import { MarketController } from "./interface/controller/marketController";
-import { SyncController } from "./interface/controller/syncController";
-import { CommunityController } from "./interface/controller/communityController";
+import { appContainer } from "./app/container";
+import { createApp, resolveCorsOrigin } from "./app/createApp";
 
 /**
  * Gold Volatility Bunseki API (Hono / Bun.serve)
  * @responsibility: アプリケーションのエントリポイント。各コンポーネントを組み立て、APIを起動する。
  */
-
-const app = new OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>();
-
-export type AppType = typeof app;
-
-// 1. グローバル設定 (Security Headers / CORS)
-const allowedOrigins = getAllowedOrigins();
-
-/**
- * resolveCorsOrigin はリクエスト Origin が許可済みかを判定します。
- * @responsibility 未知の Origin に CORS 許可ヘッダーを返さない fail-closed な制御を行う。
- */
-export function resolveCorsOrigin(origin: string | undefined): string | undefined {
-  return origin && allowedOrigins.includes(origin) ? origin : undefined;
-}
-
-app.use("*", secureHeaders());
-app.use("*", requestIdMiddleware());
-app.use("*", structuredLogger());
-
-app.use(
-  "*",
-  cors({
-    origin: (origin) => resolveCorsOrigin(origin),
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization", "Accept"],
-    credentials: true,
-  }),
-);
-
-// 2. DI ミドルウェア (依存オブジェクトの注入)
-app.use("*", diMiddleware());
-
-// 2.5 APIキー認証 (データ同期APIの保護)
 /**
  * validateStartupEnv はAPI起動に必要な環境変数を検証する関数です。
  * @responsibility APIトークン未設定のまま同期APIを公開しないよう起動を停止する。
@@ -74,54 +22,12 @@ export function validateStartupEnv(): void {
 validateStartupEnv();
 const apiToken = process.env.API_TOKEN as string;
 
-app.use("/api/v1/sync/*", syncBearerAuth(apiToken));
-
-// 2.8 Auth 関連 (better-auth)
-app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
-
-// 3. OpenAPI / Swagger 設定
-app.doc("/doc", {
-  openapi: "3.0.0",
-  info: {
-    version: "1.0.0",
-    title: "Gold Volatility Bunseki API",
-    description: "Goldボラティリティ分析ツールのバックエンドAPI",
-  },
-});
-app.get("/swagger", swaggerUI({ url: "/doc" }));
-
-// 4. ルーティングの登録
-// ==========================================
-
-// Health Check
-app.openapi(routes.healthRoute, (c) =>
-  c.json({ status: "ok", server: "Hono/Bun" }),
-);
-
-// Sync Status & Operations
-app.openapi(routes.syncStatusRoute, SyncController.getSyncStatus);
-
-app.openapi(routes.syncDataRoute, SyncController.receiveSyncData);
-app.openapi(routes.syncSeedRoute, SyncController.receiveSeedData);
-
-// Market Data (Price, ZigZag, Sessions)
-app.openapi(routes.latestPriceRoute, MarketController.getLatestPrice);
-app.openapi(routes.calculateZigZagRoute, MarketController.calculateZigZag);
-app.openapi(routes.marketSessionsRoute, MarketController.getRecentSessions);
-app.openapi(routes.eventReplayRoute, MarketController.getEventReplay);
-app.openapi(routes.marketIndicatorsRoute, MarketController.getIndicators);
-
-// Community Board
-app.openapi(routes.communityThreadsRoute, CommunityController.getThreads);
-app.openapi(routes.createCommunityThreadRoute, CommunityController.createThread);
-
-app.notFound(handleNotFound);
-app.onError(handleAppError);
+const app = createApp(appContainer, { apiToken });
+export type AppType = typeof app;
+export { app, resolveCorsOrigin };
 
 /* Bun.serve でHTTPサーバーを起動 (Docker/VPS環境用) */
 const port = parseInt(process.env.PORT ?? "3000", 10);
-
-export { app };
 
 export default {
   port,

--- a/apps/backend/src/interface/controller/communityController.ts
+++ b/apps/backend/src/interface/controller/communityController.ts
@@ -1,51 +1,43 @@
 import { Context } from 'hono';
 import { Bindings, AppVariables } from '../types';
-import { GetCommunityThreadsUseCase } from '../../application/use_case/getCommunityThreadsUseCase';
-import { CreateCommunityThreadUseCase } from '../../application/use_case/createCommunityThreadUseCase';
 import { CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+import { AppContainer } from '../../app/container';
 
 /**
- * CommunityController は掲示板スレッドに関するリクエストを処理します。
+ * createCommunityController は掲示板スレッドに関するリクエストを処理するハンドラを作成します。
  * @responsibility 掲示板スレッドに関する HTTP リクエストのバリデーションとユースケースの実行を制御する。
  */
-export class CommunityController {
-  /* c8 ignore next */
-  constructor() {}
+export function createCommunityController(container: AppContainer) {
+  return {
+    /**
+     * スレッド一覧の取得
+     * @responsibility ユースケースを実行し、スレッド一覧を JSON 形式で返す。
+     */
+    getThreads: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      try {
+        const threads = await container.useCases.community.getThreads.execute();
+        return c.json({ threads }, 200);
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error('[Community Threads Error]', error.message);
+        return c.json({ error: 'スレッド一覧の取得に失敗しました' }, 500);
+      }
+    },
 
-  /**
-   * スレッド一覧の取得
-   * @responsibility ユースケースを実行し、スレッド一覧を JSON 形式で返す。
-   */
-  static async getThreads(
-    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
-  ) {
-    try {
-      const useCase = new GetCommunityThreadsUseCase(c.get('communityThreadRepo'));
-      const threads = await useCase.execute();
-      return c.json({ threads }, 200);
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      console.error('[Community Threads Error]', error.message);
-      return c.json({ error: 'スレッド一覧の取得に失敗しました' }, 500);
-    }
-  }
-
-  /**
-   * スレッドの新規作成
-   * @responsibility リクエストボディをバリデーションし、ユースケースを実行して新規スレッドを返す。
-   */
-  static async createThread(
-    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
-  ) {
-    try {
-      const input = c.req.valid('json' as never) as CreateCommunityThreadInput;
-      const useCase = new CreateCommunityThreadUseCase(c.get('communityThreadRepo'));
-      const thread = await useCase.execute(input);
-      return c.json(thread, 201);
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      console.error('[Community Thread Create Error]', error.message);
-      return c.json({ error: 'スレッドの作成に失敗しました' }, 500);
-    }
-  }
+    /**
+     * スレッドの新規作成
+     * @responsibility リクエストボディをバリデーションし、ユースケースを実行して新規スレッドを返す。
+     */
+    createThread: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      try {
+        const input = c.req.valid('json' as never) as CreateCommunityThreadInput;
+        const thread = await container.useCases.community.createThread.execute(input);
+        return c.json(thread, 201);
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error('[Community Thread Create Error]', error.message);
+        return c.json({ error: 'スレッドの作成に失敗しました' }, 500);
+      }
+    },
+  };
 }

--- a/apps/backend/src/interface/controller/communityController.ts
+++ b/apps/backend/src/interface/controller/communityController.ts
@@ -14,14 +14,8 @@ export function createCommunityController(container: AppContainer) {
      * @responsibility ユースケースを実行し、スレッド一覧を JSON 形式で返す。
      */
     getThreads: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
-      try {
-        const threads = await container.useCases.community.getThreads.execute();
-        return c.json({ threads }, 200);
-      } catch (err: unknown) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        console.error('[Community Threads Error]', error.message);
-        return c.json({ error: 'スレッド一覧の取得に失敗しました' }, 500);
-      }
+      const threads = await container.useCases.community.getThreads.execute();
+      return c.json({ threads }, 200);
     },
 
     /**
@@ -29,15 +23,9 @@ export function createCommunityController(container: AppContainer) {
      * @responsibility リクエストボディをバリデーションし、ユースケースを実行して新規スレッドを返す。
      */
     createThread: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
-      try {
-        const input = c.req.valid('json' as never) as CreateCommunityThreadInput;
-        const thread = await container.useCases.community.createThread.execute(input);
-        return c.json(thread, 201);
-      } catch (err: unknown) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        console.error('[Community Thread Create Error]', error.message);
-        return c.json({ error: 'スレッドの作成に失敗しました' }, 500);
-      }
+      const input = c.req.valid('json' as never) as CreateCommunityThreadInput;
+      const thread = await container.useCases.community.createThread.execute(input);
+      return c.json(thread, 201);
     },
   };
 }

--- a/apps/backend/src/interface/controller/test/communityController.test.ts
+++ b/apps/backend/src/interface/controller/test/communityController.test.ts
@@ -1,8 +1,8 @@
 import { expect, describe, it, mock, beforeEach } from 'bun:test';
-import { CommunityController } from '../communityController';
+import { createCommunityController } from '../communityController';
 import { createMockContext } from '../../test/testHelpers';
-import { AppVariables } from '../../types';
 import { CommunityThread } from '../../../domain/entities/communityThread';
+import { AppContainer } from '../../../app/container';
 
 interface MockResponse {
   body: Record<string, unknown> & {
@@ -28,19 +28,21 @@ const mockThread: CommunityThread = {
  * @responsibility: 掲示板スレッドの一覧取得・作成APIの正常系・異常系を検証する。
  */
 describe('CommunityController', () => {
-  it('クラスをインスタンス化できること', () => {
-    expect(new CommunityController()).toBeInstanceOf(CommunityController);
-  });
-
-  let mockRepos: Partial<AppVariables>;
+  let container: AppContainer;
+  let getThreadsExecute: ReturnType<typeof mock>;
+  let createThreadExecute: ReturnType<typeof mock>;
 
   beforeEach(() => {
-    mockRepos = {
-      communityThreadRepo: {
-        findAll: mock(() => Promise.resolve([mockThread])),
-        create: mock(() => Promise.resolve(mockThread)),
-      } as unknown as AppVariables['communityThreadRepo'],
-    };
+    getThreadsExecute = mock(() => Promise.resolve([mockThread]));
+    createThreadExecute = mock(() => Promise.resolve(mockThread));
+    container = {
+      useCases: {
+        community: {
+          getThreads: { execute: getThreadsExecute },
+          createThread: { execute: createThreadExecute },
+        },
+      },
+    } as unknown as AppContainer;
   });
 
   // ==========================================
@@ -49,26 +51,28 @@ describe('CommunityController', () => {
   describe('getThreads', () => {
     it('スレッド一覧を取得して 200 を返すこと', async () => {
       // ## Arrange ##
-      const c = createMockContext(mockRepos);
+      const controller = createCommunityController(container);
+      const c = createMockContext({});
 
       // ## Act ##
-      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+      const res = (await controller.getThreads(c)) as unknown as MockResponse;
 
       // ## Assert ##
       expect(res.status).toBe(200);
       expect(res.body.threads).toHaveLength(1);
       expect(res.body.threads?.[0].id).toBe(mockThread.id);
+      expect(getThreadsExecute).toHaveBeenCalledTimes(1);
     });
 
     it('リポジトリが空配列を返した場合、空の threads 配列と 200 を返すこと', async () => {
       // ## Arrange ##
-      if (mockRepos.communityThreadRepo) {
-        mockRepos.communityThreadRepo.findAll = mock(() => Promise.resolve([]));
-      }
-      const c = createMockContext(mockRepos);
+      getThreadsExecute = mock(() => Promise.resolve([]));
+      container.useCases.community.getThreads.execute = getThreadsExecute;
+      const controller = createCommunityController(container);
+      const c = createMockContext({});
 
       // ## Act ##
-      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+      const res = (await controller.getThreads(c)) as unknown as MockResponse;
 
       // ## Assert ##
       expect(res.status).toBe(200);
@@ -77,15 +81,13 @@ describe('CommunityController', () => {
 
     it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
       // ## Arrange ##
-      if (mockRepos.communityThreadRepo) {
-        mockRepos.communityThreadRepo.findAll = mock(() =>
-          Promise.reject(new Error('DB接続エラー')),
-        );
-      }
-      const c = createMockContext(mockRepos);
+      getThreadsExecute = mock(() => Promise.reject(new Error('DB接続エラー')));
+      container.useCases.community.getThreads.execute = getThreadsExecute;
+      const controller = createCommunityController(container);
+      const c = createMockContext({});
 
       // ## Act ##
-      const res = (await CommunityController.getThreads(c)) as unknown as MockResponse;
+      const res = (await controller.getThreads(c)) as unknown as MockResponse;
 
       // ## Assert ##
       expect(res.status).toBe(500);
@@ -104,33 +106,33 @@ describe('CommunityController', () => {
         body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
         category: 'Market Discussion',
       };
-      const c = createMockContext(mockRepos, {}, body as Record<string, string>);
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, body as Record<string, string>);
 
       // ## Act ##
-      const res = (await CommunityController.createThread(c)) as unknown as MockResponse;
+      const res = (await controller.createThread(c)) as unknown as MockResponse;
 
       // ## Assert ##
       expect(res.status).toBe(201);
       expect(res.body.id).toBe(mockThread.id);
       expect(res.body.title).toBe(mockThread.title);
+      expect(createThreadExecute).toHaveBeenCalledWith(body);
     });
 
     it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
       // ## Arrange ##
-      if (mockRepos.communityThreadRepo) {
-        mockRepos.communityThreadRepo.create = mock(() =>
-          Promise.reject(new Error('INSERT失敗')),
-        );
-      }
+      createThreadExecute = mock(() => Promise.reject(new Error('INSERT失敗')));
+      container.useCases.community.createThread.execute = createThreadExecute;
       const body = {
         title: 'NFP後の戻りについて',
         body: '本文です。',
         category: 'General',
       };
-      const c = createMockContext(mockRepos, {}, body as Record<string, string>);
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, body as Record<string, string>);
 
       // ## Act ##
-      const res = (await CommunityController.createThread(c)) as unknown as MockResponse;
+      const res = (await controller.createThread(c)) as unknown as MockResponse;
 
       // ## Assert ##
       expect(res.status).toBe(500);

--- a/apps/backend/src/interface/controller/test/communityController.test.ts
+++ b/apps/backend/src/interface/controller/test/communityController.test.ts
@@ -7,7 +7,6 @@ import { AppContainer } from '../../../app/container';
 interface MockResponse {
   body: Record<string, unknown> & {
     threads?: CommunityThread[];
-    error?: string;
     id?: string;
     title?: string;
   };
@@ -79,19 +78,15 @@ describe('CommunityController', () => {
       expect(res.body.threads).toHaveLength(0);
     });
 
-    it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
+    it('ユースケースがエラーをスローした場合、グローバルエラーハンドラーへ委譲すること', async () => {
       // ## Arrange ##
       getThreadsExecute = mock(() => Promise.reject(new Error('DB接続エラー')));
       container.useCases.community.getThreads.execute = getThreadsExecute;
       const controller = createCommunityController(container);
       const c = createMockContext({});
 
-      // ## Act ##
-      const res = (await controller.getThreads(c)) as unknown as MockResponse;
-
-      // ## Assert ##
-      expect(res.status).toBe(500);
-      expect(res.body.error).toBe('スレッド一覧の取得に失敗しました');
+      // ## Act & Assert ##
+      await expect(controller.getThreads(c)).rejects.toThrow('DB接続エラー');
     });
   });
 
@@ -119,7 +114,7 @@ describe('CommunityController', () => {
       expect(createThreadExecute).toHaveBeenCalledWith(body);
     });
 
-    it('リポジトリがエラーをスローした場合、500 を返すこと', async () => {
+    it('ユースケースがエラーをスローした場合、グローバルエラーハンドラーへ委譲すること', async () => {
       // ## Arrange ##
       createThreadExecute = mock(() => Promise.reject(new Error('INSERT失敗')));
       container.useCases.community.createThread.execute = createThreadExecute;
@@ -131,12 +126,8 @@ describe('CommunityController', () => {
       const controller = createCommunityController(container);
       const c = createMockContext({}, {}, body as Record<string, string>);
 
-      // ## Act ##
-      const res = (await controller.createThread(c)) as unknown as MockResponse;
-
-      // ## Assert ##
-      expect(res.status).toBe(500);
-      expect(res.body.error).toBe('スレッドの作成に失敗しました');
+      // ## Act & Assert ##
+      await expect(controller.createThread(c)).rejects.toThrow('INSERT失敗');
     });
   });
 });

--- a/apps/backend/src/interface/middleware/diMiddleware.test.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.test.ts
@@ -14,7 +14,7 @@ describe("diMiddleware", () => {
     const middleware = diMiddleware();
     await middleware(c, next);
 
-    expect(set).toHaveBeenCalledTimes(6);
+    expect(set).toHaveBeenCalledTimes(5);
     expect(next).toHaveBeenCalled();
 
     // セットされたキーの確認
@@ -24,6 +24,6 @@ describe("diMiddleware", () => {
     expect(calledKeys).toContain("sessionRepo");
     expect(calledKeys).toContain("syncRepo");
     expect(calledKeys).toContain("batchRepo");
-    expect(calledKeys).toContain("communityThreadRepo");
+    expect(calledKeys).not.toContain("communityThreadRepo");
   });
 });

--- a/apps/backend/src/interface/middleware/diMiddleware.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.ts
@@ -1,30 +1,21 @@
 import { MiddlewareHandler } from 'hono';
-
-// Infrastructure
-import { db } from '../../infrastructure/database/db';
-import { DrizzleSyncRepository } from '../../infrastructure/repository/drizzleSyncRepository';
-import { DrizzlePriceRepository } from '../../infrastructure/repository/drizzlePriceRepository';
-import { DrizzleZigZagRepository } from '../../infrastructure/repository/drizzleZigZagRepository';
-import { DrizzleSessionRepository } from '../../infrastructure/repository/drizzleSessionRepository';
-import { DrizzleBatchRepository } from '../../infrastructure/repository/drizzleBatchRepository';
-import { DrizzleCommunityThreadRepository } from '../../infrastructure/repository/drizzleCommunityThreadRepository';
+import { AppContainer, appContainer } from '../../app/container';
 
 /**
  * diMiddleware は、リクエスト毎に必要な依存オブジェクトを Context に注入します。
  * @responsibility: インフラ層の具体的実装をインスタンス化し、インターフェースを通じてアプリケーション層に提供する。
  */
-export const diMiddleware = (): MiddlewareHandler => {
+export const diMiddleware = (container: AppContainer = appContainer): MiddlewareHandler => {
   return async (c, next) => {
+    const { repositories } = container;
 
-    // 依存オブジェクトの注入
-    // Note: パフォーマンス向上のため、必要に応じてシングルトン化を検討可能ですが、
-    // 現時点ではクリーンなステート管理のためリクエスト毎にセットします。
-    c.set('priceRepo', new DrizzlePriceRepository(db));
-    c.set('zigzagRepo', new DrizzleZigZagRepository(db));
-    c.set('sessionRepo', new DrizzleSessionRepository(db));
-    c.set('syncRepo', new DrizzleSyncRepository(db));
-    c.set('batchRepo', new DrizzleBatchRepository(db));
-    c.set('communityThreadRepo', new DrizzleCommunityThreadRepository(db));
+    // 依存オブジェクトの注入。インスタンス生成は AppContainer に集約する。
+    c.set('priceRepo', repositories.priceRepo);
+    c.set('zigzagRepo', repositories.zigzagRepo);
+    c.set('sessionRepo', repositories.sessionRepo);
+    c.set('syncRepo', repositories.syncRepo);
+    c.set('batchRepo', repositories.batchRepo);
+    c.set('communityThreadRepo', repositories.communityThreadRepo);
 
     await next();
   };

--- a/apps/backend/src/interface/middleware/diMiddleware.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.ts
@@ -15,7 +15,6 @@ export const diMiddleware = (container: AppContainer = appContainer): Middleware
     c.set('sessionRepo', repositories.sessionRepo);
     c.set('syncRepo', repositories.syncRepo);
     c.set('batchRepo', repositories.batchRepo);
-    c.set('communityThreadRepo', repositories.communityThreadRepo);
 
     await next();
   };

--- a/apps/backend/src/interface/routes/communityRoutes.ts
+++ b/apps/backend/src/interface/routes/communityRoutes.ts
@@ -1,0 +1,18 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { AppContainer } from '../../app/container';
+import { createCommunityController } from '../controller/communityController';
+import { AppVariables, Bindings } from '../types';
+import { communityThreadsRoute, createCommunityThreadRoute } from './openapi';
+
+type BackendApp = OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>;
+
+/**
+ * registerCommunityRoutes は掲示板APIのルート登録を行います。
+ * @responsibility 掲示板ドメインの route 定義と controller を結びつける。
+ */
+export function registerCommunityRoutes(app: BackendApp, container: AppContainer): void {
+  const controller = createCommunityController(container);
+
+  app.openapi(communityThreadsRoute, controller.getThreads);
+  app.openapi(createCommunityThreadRoute, controller.createThread);
+}

--- a/apps/backend/src/interface/routes/test/apiIntegration.test.ts
+++ b/apps/backend/src/interface/routes/test/apiIntegration.test.ts
@@ -1,12 +1,7 @@
 import { expect, describe, it, mock, beforeAll, afterAll } from "bun:test";
+import { createApp } from "../../../app/createApp";
+import { createAppContainer } from "../../../app/container";
 import { createMockDrizzle } from "../../test/testHelpers";
-
-// DB をモックしてテスト時に実際のDB接続を発生させない
-mock.module("../../../infrastructure/database/db", () => ({
-  db: createMockDrizzle([]),
-}));
-
-import { app } from "../../../index";
 
 /**
  * API Response Integrity Tests (Integration)
@@ -15,6 +10,9 @@ import { app } from "../../../index";
  */
 describe("API Response Integrity Tests (Integration)", () => {
   let originalFetch: typeof globalThis.fetch;
+  const app = createApp(createAppContainer(createMockDrizzle([])), {
+    apiToken: "ci-test-token",
+  });
 
   beforeAll(() => {
     originalFetch = globalThis.fetch;
@@ -27,10 +25,7 @@ describe("API Response Integrity Tests (Integration)", () => {
     globalThis.fetch = originalFetch;
   });
 
-  // 注: index.ts の DI ミドルウェアで db シングルトンが直接使われているため、
-  // 完全に分離したインテグレーションテストにするには、本来は DI を差し替え可能にする必要がある。
-  // 現状はコントローラーのテストで十分カバーされているが、
-  // ここでは最低限の不整合を解消するためにダミーの環境変数を渡す。
+  // createApp に mock container を渡すことで、実DB接続を発生させずに統合テストを行う。
   const mockEnv = {
     DATABASE_URL: "postgresql://mock:mock@localhost:5432/mock",
     ANALYTICS_SERVICE_URL: "http://mock-service",

--- a/apps/backend/src/interface/types.ts
+++ b/apps/backend/src/interface/types.ts
@@ -4,7 +4,6 @@ import { ZigZagRepositoryPort } from '../application/port/zigzagRepositoryPort';
 import { SessionRepositoryPort } from '../application/port/sessionRepositoryPort';
 import { DrizzleBatchRepository } from '../infrastructure/repository/drizzleBatchRepository';
 import { AnalyticsServicePort } from '../application/port/analyticsServicePort';
-import { CommunityThreadRepositoryPort } from '../application/port/communityThreadRepositoryPort';
 
 /**
  * Bindings は 環境変数などの定義です。
@@ -25,5 +24,4 @@ export type AppVariables = {
   sessionRepo: SessionRepositoryPort;
   batchRepo: DrizzleBatchRepository;
   analyticsService: AnalyticsServicePort;
-  communityThreadRepo: CommunityThreadRepositoryPort;
 };


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #81

# Todo

- [x] AppContainer を追加し、Repository / 掲示板 UseCase の生成を一箇所に集約
- [x] `diMiddleware` を Container から Context に依存を渡すだけの責務に変更
- [x] `CommunityController` を static class から Container 注入の handler factory に変更
- [x] 掲示板ルート登録を `communityRoutes.ts` に切り出し
- [x] `createApp(container, options)` を追加し、統合テストで mock container を注入可能に変更
- [x] `index.ts` を起動用エントリポイントへ縮小
- [x] Review: `appContainer` の依存配線を freeze して accidental mutation を防止
- [x] Review: CommunityController の独自 `console.error` をやめ、グローバルエラーハンドラーへ委譲
- [x] Review: 不要になった `communityThreadRepo` の Context 注入を削除

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all

cd apps/backend
bunx tsc --noEmit
bun test src/app/container.test.ts src/interface/controller/test/communityController.test.ts src/interface/middleware/diMiddleware.test.ts src/interface/routes/test/apiIntegration.test.ts src/securityMiddleware.test.ts
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-04 10:15 (JST)
- ブランチ: refactor/issue-81-app-container-community

```
bun test src/app/container.test.ts src/interface/controller/test/communityController.test.ts src/interface/middleware/diMiddleware.test.ts src/interface/routes/test/apiIntegration.test.ts src/securityMiddleware.test.ts

18 pass
0 fail
49 expect() calls
```

```
cd apps/backend && bunx tsc --noEmit
pass
```

```
bun run test:all

frontend: 45 pass / 0 fail
backend: 91 pass / 0 fail
```

```
bun run lint:all
pass
```

</details>

# Related Links

- Issue #81