### PR TITLE
[BE] Sync APIをAppContainer注入と専用routesへ移行する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,28 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-04 - Issue #83 Sync APIのAppContainer/routes移行PR
+
+- **達成したタスク**:
+  - Issue #83 `[BE] Sync APIをAppContainer注入と専用routesへ移行する` を作成。
+  - `refactor/issue-83-sync-container-routes` ブランチを `develop` から作成。
+  - AppContainer に Sync 用 `GetSyncStatusUseCase` の配線を追加。
+  - `SyncController` を static class から `createSyncController(container)` の handler factory に変更。
+  - `apps/backend/src/interface/routes/syncRoutes.ts` を追加し、Sync API の route 登録を `createApp.ts` から分離。
+  - `syncRepo` の Hono Context 注入と `AppVariables` 型定義を削除。
+  - セルフレビューで、Sync POST 異常系の既存API契約 `{ success: false, message }` を維持するよう調整。
+  - PR #84 `https://github.com/somadevfat/gold-bunseki-web/pull/84` を `develop` 向けに作成。
+
+- **検証結果**:
+  - targeted backend tests: 18 pass / 0 fail
+  - `cd apps/backend && bunx tsc --noEmit`: pass
+  - `bun run test:all`: frontend 45 pass / backend 90 pass
+  - `bun run lint:all`: pass
+
+- **次回への申し送り事項**:
+  - PR #84 マージ後、MarketController / marketRoutes を同じパターンで移行すると、`diMiddleware` から `priceRepo`, `zigzagRepo`, `sessionRepo`, `batchRepo` の Context 注入も段階的に削除できる。
+  - 未追跡の `.agents/skills/self-implement/` と `docs/archives/auth_strategy_zenn.md` は今回PRに含めていない。
+
 ### 2026-05-04 - PR #82 Geminiレビュー対応
 
 - **達成したタスク**:

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
 import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
+import { GetSyncStatusUseCase } from '../application/use_case/getSyncStatusUseCase';
 import { createAppContainer, freezeAppContainer } from './container';
 import { createMockDrizzle } from '../interface/test/testHelpers';
 
@@ -13,6 +14,7 @@ describe('createAppContainer', () => {
     expect(container.repositories.syncRepo).toBeDefined();
     expect(container.useCases.community.getThreads).toBeInstanceOf(GetCommunityThreadsUseCase);
     expect(container.useCases.community.createThread).toBeInstanceOf(CreateCommunityThreadUseCase);
+    expect(container.useCases.sync.getStatus).toBeInstanceOf(GetSyncStatusUseCase);
   });
 
   it('グローバル利用するContainerの依存配線をfreezeできること', () => {
@@ -22,5 +24,6 @@ describe('createAppContainer', () => {
     expect(Object.isFrozen(container.repositories)).toBe(true);
     expect(Object.isFrozen(container.useCases)).toBe(true);
     expect(Object.isFrozen(container.useCases.community)).toBe(true);
+    expect(Object.isFrozen(container.useCases.sync)).toBe(true);
   });
 });

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -1,5 +1,6 @@
 import { GetCommunityThreadsUseCase } from "../application/use_case/getCommunityThreadsUseCase";
 import { CreateCommunityThreadUseCase } from "../application/use_case/createCommunityThreadUseCase";
+import { GetSyncStatusUseCase } from "../application/use_case/getSyncStatusUseCase";
 import { db, DbType } from "../infrastructure/database/db";
 import { DrizzleBatchRepository } from "../infrastructure/repository/drizzleBatchRepository";
 import { DrizzleCommunityThreadRepository } from "../infrastructure/repository/drizzleCommunityThreadRepository";
@@ -14,13 +15,14 @@ import { DrizzleZigZagRepository } from "../infrastructure/repository/drizzleZig
  */
 export function createAppContainer(database: DbType = db) {
   const communityThreadRepo = new DrizzleCommunityThreadRepository(database);
+  const syncRepo = new DrizzleSyncRepository(database);
 
   return {
     repositories: {
       priceRepo: new DrizzlePriceRepository(database),
       zigzagRepo: new DrizzleZigZagRepository(database),
       sessionRepo: new DrizzleSessionRepository(database),
-      syncRepo: new DrizzleSyncRepository(database),
+      syncRepo,
       batchRepo: new DrizzleBatchRepository(database),
       communityThreadRepo,
     },
@@ -28,6 +30,9 @@ export function createAppContainer(database: DbType = db) {
       community: {
         getThreads: new GetCommunityThreadsUseCase(communityThreadRepo),
         createThread: new CreateCommunityThreadUseCase(communityThreadRepo),
+      },
+      sync: {
+        getStatus: new GetSyncStatusUseCase(syncRepo),
       },
     },
   };
@@ -42,6 +47,7 @@ export type AppContainer = ReturnType<typeof createAppContainer>;
 export function freezeAppContainer(container: AppContainer): AppContainer {
   Object.freeze(container.repositories);
   Object.freeze(container.useCases.community);
+  Object.freeze(container.useCases.sync);
   Object.freeze(container.useCases);
 
   return Object.freeze(container);

--- a/apps/backend/src/app/createApp.ts
+++ b/apps/backend/src/app/createApp.ts
@@ -15,10 +15,10 @@ import { structuredLogger } from "../interface/middleware/structuredLogger";
 import { syncBearerAuth } from "../interface/middleware/syncBearerAuth";
 import { Bindings, AppVariables } from "../interface/types";
 import { registerCommunityRoutes } from "../interface/routes/communityRoutes";
+import { registerSyncRoutes } from "../interface/routes/syncRoutes";
 
 // Controllers
 import { MarketController } from "../interface/controller/marketController";
-import { SyncController } from "../interface/controller/syncController";
 
 const defaultAllowedOrigins = getAllowedOrigins();
 
@@ -83,9 +83,7 @@ export function createApp(
     c.json({ status: "ok", server: "Hono/Bun" }),
   );
 
-  app.openapi(routes.syncStatusRoute, SyncController.getSyncStatus);
-  app.openapi(routes.syncDataRoute, SyncController.receiveSyncData);
-  app.openapi(routes.syncSeedRoute, SyncController.receiveSeedData);
+  registerSyncRoutes(app, container);
 
   app.openapi(routes.latestPriceRoute, MarketController.getLatestPrice);
   app.openapi(routes.calculateZigZagRoute, MarketController.calculateZigZag);

--- a/apps/backend/src/interface/controller/syncController.ts
+++ b/apps/backend/src/interface/controller/syncController.ts
@@ -1,67 +1,56 @@
 import { Context } from "hono";
 import { Bindings, AppVariables } from "../types";
-import { GetSyncStatusUseCase } from "../../application/use_case/getSyncStatusUseCase";
 import { SyncPayload } from "../../infrastructure/repository/drizzleBatchRepository";
+import { AppContainer } from "../../app/container";
 
 /**
- * SyncController はデータの同期ステータス確認および同期実行リクエストを処理します。
+ * createSyncController はデータの同期ステータス確認および同期実行リクエストを処理するハンドラを作成します。
+ * @responsibility Sync API の HTTP リクエストを AppContainer 上の依存へ橋渡しする。
  */
-export class SyncController {
-  /* c8 ignore next */
-  constructor() {}
+export function createSyncController(container: AppContainer) {
+  return {
+    /**
+     * 同期ステータスの取得
+     */
+    getSyncStatus: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const status = await container.useCases.sync.getStatus.execute();
+      return c.json(status, 200);
+    },
 
-  /**
-   * 同期ステータスの取得
-   */
-  static async getSyncStatus(
-    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
-  ) {
-    const useCase = new GetSyncStatusUseCase(c.get("syncRepo"));
-    const status = await useCase.execute();
-    return c.json(status, 200);
-  }
+    /**
+     * 同期データ受取 (Push型) - 常用
+     */
+    receiveSyncData: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      try {
+        const payload = (await c.req.valid("json" as never)) as SyncPayload;
+        await container.repositories.batchRepo.saveAll(payload);
 
-  /**
-   * 同期データ受取 (Push型) - 常用
-   */
-  static async receiveSyncData(
-    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
-  ) {
-    try {
-      const payload = (await c.req.valid("json" as never)) as SyncPayload;
-      console.log("[Sync:Push] Received direct data push (Incremental)...");
-      await c.get("batchRepo").saveAll(payload);
+        return c.json({ success: true, message: "差分同期成功 (Push)" }, 200);
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        return c.json(
+          { success: false, message: `差分Push同期失敗: ${error.message}` },
+          500,
+        );
+      }
+    },
 
-      return c.json({ success: true, message: "差分同期成功 (Push)" }, 200);
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      console.error("[Sync:Push Error]", error.message);
-      return c.json(
-        { success: false, message: `差分Push同期失敗: ${error.message}` },
-        500,
-      );
-    }
-  }
+    /**
+     * シードデータ受取 (Push型) - 初回大量データ用
+     */
+    receiveSeedData: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      try {
+        const payload = (await c.req.valid("json" as never)) as SyncPayload;
+        await container.repositories.batchRepo.saveAll(payload);
 
-  /**
-   * シードデータ受取 (Push型) - 初回大量データ用
-   */
-  static async receiveSeedData(
-    c: Context<{ Bindings: Bindings; Variables: AppVariables }>,
-  ) {
-    try {
-      const payload = (await c.req.valid("json" as never)) as SyncPayload;
-      console.log("[Sync:Seed] Received massive seed data push...");
-      await c.get("batchRepo").saveAll(payload);
-
-      return c.json({ success: true, message: "シードデータ保存成功" }, 200);
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      console.error("[Sync:Seed Error]", error.message);
-      return c.json(
-        { success: false, message: `シードデータ保存失敗: ${error.message}` },
-        500,
-      );
-    }
-  }
+        return c.json({ success: true, message: "シードデータ保存成功" }, 200);
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        return c.json(
+          { success: false, message: `シードデータ保存失敗: ${error.message}` },
+          500,
+        );
+      }
+    },
+  };
 }

--- a/apps/backend/src/interface/controller/test/syncController.test.ts
+++ b/apps/backend/src/interface/controller/test/syncController.test.ts
@@ -1,7 +1,8 @@
 import { expect, describe, it, mock, beforeEach } from "bun:test";
-import { SyncController } from "../syncController";
+import { createSyncController } from "../syncController";
 import { createMockContext } from "../../test/testHelpers";
-import { AppVariables, Bindings } from "../../types";
+import { Bindings } from "../../types";
+import { AppContainer } from "../../../app/container";
 
 interface MockResponse {
   body: { success: boolean; message: string; syncHealth?: string };
@@ -9,29 +10,32 @@ interface MockResponse {
 }
 
 describe("SyncController", () => {
-  it("クラスをインスタンス化できること", () => {
-    expect(new SyncController()).toBeInstanceOf(SyncController);
-  });
-  let mockRepos: Partial<AppVariables>;
+  let container: AppContainer;
+  let getStatusExecute: ReturnType<typeof mock>;
+  let saveAll: ReturnType<typeof mock>;
   let mockEnv: Partial<Bindings>;
 
   beforeEach(() => {
-    mockRepos = {
-      syncRepo: {
-        getSyncStatus: mock(() =>
-          Promise.resolve({
-            lastCandleAt: "now",
-            lastSessionAt: "now",
-            lastEventAt: "now",
-            totalCandles: 100,
-            syncHealth: "Healthy",
-          }),
-        ),
-      } as unknown as AppVariables["syncRepo"],
-      batchRepo: {
-        saveAll: mock(() => Promise.resolve(true)),
-      } as unknown as AppVariables["batchRepo"],
-    };
+    getStatusExecute = mock(() =>
+      Promise.resolve({
+        lastCandleAt: "now",
+        lastSessionAt: "now",
+        lastEventAt: "now",
+        totalCandles: 100,
+        syncHealth: "Healthy",
+      }),
+    );
+    saveAll = mock(() => Promise.resolve(true));
+    container = {
+      repositories: {
+        batchRepo: { saveAll },
+      },
+      useCases: {
+        sync: {
+          getStatus: { execute: getStatusExecute },
+        },
+      },
+    } as unknown as AppContainer;
 
     mockEnv = {
       ANALYTICS_SERVICE_URL: "http://mock-service",
@@ -40,36 +44,32 @@ describe("SyncController", () => {
 
   describe("getSyncStatus", () => {
     it("同期ステータスを取得して 200 で返すこと", async () => {
-      const c = createMockContext(mockRepos, mockEnv);
-      const res = (await SyncController.getSyncStatus(
-        c,
-      )) as unknown as MockResponse;
+      const controller = createSyncController(container);
+      const c = createMockContext({}, mockEnv);
+      const res = (await controller.getSyncStatus(c)) as unknown as MockResponse;
       expect(res.status).toBe(200);
       expect(res.body.syncHealth).toBe("Healthy");
+      expect(getStatusExecute).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("receiveSeedData", () => {
     it("シードデータ保存に成功した場合 200 を返すこと", async () => {
-      const c = createMockContext(mockRepos, mockEnv);
-      const res = (await SyncController.receiveSeedData(
-        c,
-      )) as unknown as MockResponse;
+      const controller = createSyncController(container);
+      const c = createMockContext({}, mockEnv);
+      const res = (await controller.receiveSeedData(c)) as unknown as MockResponse;
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(mockRepos.batchRepo?.saveAll).toHaveBeenCalled();
+      expect(saveAll).toHaveBeenCalled();
     });
 
-    it("例外発生時に 500 を返すこと", async () => {
-      if (mockRepos.batchRepo) {
-        mockRepos.batchRepo.saveAll = mock(() =>
-          Promise.reject(new Error("Seed Error")),
-        );
-      }
-      const c = createMockContext(mockRepos, mockEnv);
-      const res = (await SyncController.receiveSeedData(
-        c,
-      )) as unknown as MockResponse;
+    it("例外発生時に既存API契約のエラーレスポンスを返すこと", async () => {
+      saveAll = mock(() => Promise.reject(new Error("Seed Error")));
+      container.repositories.batchRepo.saveAll = saveAll;
+      const controller = createSyncController(container);
+      const c = createMockContext({}, mockEnv);
+
+      const res = (await controller.receiveSeedData(c)) as unknown as MockResponse;
       expect(res.status).toBe(500);
       expect(res.body.message).toContain("Seed Error");
     });
@@ -77,25 +77,21 @@ describe("SyncController", () => {
 
   describe("receiveSyncData", () => {
     it("Push同期に成功した場合 200 を返すこと", async () => {
-      const c = createMockContext(mockRepos, mockEnv);
-      const res = (await SyncController.receiveSyncData(
-        c,
-      )) as unknown as MockResponse;
+      const controller = createSyncController(container);
+      const c = createMockContext({}, mockEnv);
+      const res = (await controller.receiveSyncData(c)) as unknown as MockResponse;
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(mockRepos.batchRepo?.saveAll).toHaveBeenCalled();
+      expect(saveAll).toHaveBeenCalled();
     });
 
-    it("例外発生時に 500 を返すこと", async () => {
-      if (mockRepos.batchRepo) {
-        mockRepos.batchRepo.saveAll = mock(() =>
-          Promise.reject(new Error("Save Error")),
-        );
-      }
-      const c = createMockContext(mockRepos, mockEnv);
-      const res = (await SyncController.receiveSyncData(
-        c,
-      )) as unknown as MockResponse;
+    it("例外発生時に既存API契約のエラーレスポンスを返すこと", async () => {
+      saveAll = mock(() => Promise.reject(new Error("Save Error")));
+      container.repositories.batchRepo.saveAll = saveAll;
+      const controller = createSyncController(container);
+      const c = createMockContext({}, mockEnv);
+
+      const res = (await controller.receiveSyncData(c)) as unknown as MockResponse;
       expect(res.status).toBe(500);
       expect(res.body.message).toContain("Save Error");
     });

--- a/apps/backend/src/interface/middleware/diMiddleware.test.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.test.ts
@@ -14,7 +14,7 @@ describe("diMiddleware", () => {
     const middleware = diMiddleware();
     await middleware(c, next);
 
-    expect(set).toHaveBeenCalledTimes(5);
+    expect(set).toHaveBeenCalledTimes(4);
     expect(next).toHaveBeenCalled();
 
     // セットされたキーの確認
@@ -22,8 +22,8 @@ describe("diMiddleware", () => {
     expect(calledKeys).toContain("priceRepo");
     expect(calledKeys).toContain("zigzagRepo");
     expect(calledKeys).toContain("sessionRepo");
-    expect(calledKeys).toContain("syncRepo");
     expect(calledKeys).toContain("batchRepo");
+    expect(calledKeys).not.toContain("syncRepo");
     expect(calledKeys).not.toContain("communityThreadRepo");
   });
 });

--- a/apps/backend/src/interface/middleware/diMiddleware.ts
+++ b/apps/backend/src/interface/middleware/diMiddleware.ts
@@ -13,7 +13,6 @@ export const diMiddleware = (container: AppContainer = appContainer): Middleware
     c.set('priceRepo', repositories.priceRepo);
     c.set('zigzagRepo', repositories.zigzagRepo);
     c.set('sessionRepo', repositories.sessionRepo);
-    c.set('syncRepo', repositories.syncRepo);
     c.set('batchRepo', repositories.batchRepo);
 
     await next();

--- a/apps/backend/src/interface/routes/syncRoutes.ts
+++ b/apps/backend/src/interface/routes/syncRoutes.ts
@@ -1,0 +1,19 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { AppContainer } from '../../app/container';
+import { createSyncController } from '../controller/syncController';
+import { AppVariables, Bindings } from '../types';
+import { syncDataRoute, syncSeedRoute, syncStatusRoute } from './openapi';
+
+type BackendApp = OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>;
+
+/**
+ * registerSyncRoutes は同期APIのルート登録を行います。
+ * @responsibility Syncドメインの route 定義と controller を結びつける。
+ */
+export function registerSyncRoutes(app: BackendApp, container: AppContainer): void {
+  const controller = createSyncController(container);
+
+  app.openapi(syncStatusRoute, controller.getSyncStatus);
+  app.openapi(syncDataRoute, controller.receiveSyncData);
+  app.openapi(syncSeedRoute, controller.receiveSeedData);
+}

--- a/apps/backend/src/interface/types.ts
+++ b/apps/backend/src/interface/types.ts
@@ -1,4 +1,3 @@
-import { SyncRepositoryPort } from '../application/port/syncRepositoryPort';
 import { PriceRepositoryPort } from '../application/port/priceRepositoryPort';
 import { ZigZagRepositoryPort } from '../application/port/zigzagRepositoryPort';
 import { SessionRepositoryPort } from '../application/port/sessionRepositoryPort';
@@ -18,7 +17,6 @@ export type Bindings = {
  */
 export type AppVariables = {
   requestId: string;
-  syncRepo: SyncRepositoryPort;
   priceRepo: PriceRepositoryPort;
   zigzagRepo: ZigZagRepositoryPort;
   sessionRepo: SessionRepositoryPort;


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #83

# Todo

- [x] AppContainer に Sync 用 UseCase を追加
- [x] `SyncController` を static class から Container 注入の handler factory に変更
- [x] Sync API のルート登録を `syncRoutes.ts` に分離
- [x] `createApp.ts` から SyncController の直接参照を削除
- [x] `syncRepo` の Context 注入と `AppVariables` 型定義を削除
- [x] `batchRepo` は MarketController 移行前のため Context 注入を維持
- [x] セルフレビューで Sync POST 異常系の既存レスポンス契約を維持するよう調整

# How to check (動作確認の手順)

```zsh
bun run lint:all
bun run test:all

cd apps/backend
bunx tsc --noEmit
bun test src/app/container.test.ts src/interface/controller/test/syncController.test.ts src/interface/middleware/diMiddleware.test.ts src/interface/routes/test/apiIntegration.test.ts src/securityMiddleware.test.ts
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-04 10:24 (JST)
- ブランチ: refactor/issue-83-sync-container-routes

```
bun test src/app/container.test.ts src/interface/controller/test/syncController.test.ts src/interface/middleware/diMiddleware.test.ts src/interface/routes/test/apiIntegration.test.ts src/securityMiddleware.test.ts

18 pass
0 fail
52 expect() calls
```

```
cd apps/backend && bunx tsc --noEmit
pass
```

```
bun run test:all

frontend: 45 pass / 0 fail
backend: 90 pass / 0 fail
```

```
bun run lint:all
pass
```

</details>

# Related Links

- Issue #83

Made with [Cursor](https://cursor.com)