### PR TITLE
[CI] developの掲示板投稿作成APIテスト失敗を修正する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,26 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-06 - PR #92 掲示板投稿作成APIテストのCI失敗修正確認
+
+- **達成したタスク**:
+  - PR #92 `[CI] developの掲示板投稿作成APIテスト失敗を修正する` のCIログを確認。
+  - 失敗していたRunは `pull/90/merge` の修正前CIで、Bun 1.3.13上のテスト順序により `mock.module("@/lib/api/client")` が期待通り効かず、`postMock` が呼ばれないことが根本原因と確認。
+  - PR #92 の既存修正で `createCommunityThread` に任意 `AppClient` 注入を追加し、テストをmodule mock依存から明示的なmock client注入へ変更済みであることを確認。
+  - Gemini Code Assistのレビューに対応し、`createMockClient` からテスト対象外の `market` API mockを削除し、community APIのみを持つ最小mockへ整理。
+
+- **変更ファイル**:
+  - `apps/frontend/src/features/community/api/createCommunityThread.test.ts`
+
+- **検証結果**:
+  - `/tmp/bun-1.3.13/bun-linux-x64/bun test apps/frontend/src/features/community/api/createCommunityThread.test.ts`: 2 pass / 0 fail
+  - `bun run test:all`: frontend 53 pass / backend 92 pass
+  - `bun run lint:all`: pass
+
+- **次回への申し送り事項**:
+  - ローカルの `gh auth status` はトークン無効のため、Actionsの再実行やPRチェック確認をCLIで行うには `gh auth login -h github.com` が必要。
+  - 作業ツリーには今回のAPIテスト修正以外に、CommunityBoard / CommunityPostForm 周辺の未コミット差分が残っている。
+
 ### 2026-05-04 - Issue #83 Sync APIのAppContainer/routes移行PR
 
 - **達成したタスク**:

--- a/apps/frontend/src/features/community/api/createCommunityThread.test.ts
+++ b/apps/frontend/src/features/community/api/createCommunityThread.test.ts
@@ -1,20 +1,26 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { createCommunityThread } from "./createCommunityThread";
+import type { AppClient } from "@/lib/api/client";
 
 const postMock = mock();
-mock.module("@/lib/api/client", () => ({
-  apiClient: {
-    api: {
-      v1: {
-        community: {
-          threads: {
-            $post: postMock,
-          },
+
+const createMockClient = (): AppClient => ({
+  api: {
+    v1: {
+      market: {
+        indicators: { $get: mock() },
+        replay: { $get: mock() },
+        sessions: { $get: mock() },
+      },
+      community: {
+        threads: {
+          $get: mock(),
+          $post: postMock,
         },
       },
     },
   },
-}));
+});
 
 describe("createCommunityThread", () => {
   beforeEach(() => {
@@ -39,7 +45,7 @@ describe("createCommunityThread", () => {
       title: "CPI発表後の反応確認",
       body: "初動とNY後半の戻りを比較したいです。",
       category: "経済指標",
-    });
+    }, createMockClient());
 
     expect(result).toEqual(thread);
     expect(postMock).toHaveBeenCalledWith(
@@ -69,6 +75,6 @@ describe("createCommunityThread", () => {
       title: "CPI発表後の反応確認",
       body: "初動とNY後半の戻りを比較したいです。",
       category: "経済指標",
-    })).rejects.toThrow("掲示板投稿の作成に失敗しました");
+    }, createMockClient())).rejects.toThrow("掲示板投稿の作成に失敗しました");
   });
 });

--- a/apps/frontend/src/features/community/api/createCommunityThread.test.ts
+++ b/apps/frontend/src/features/community/api/createCommunityThread.test.ts
@@ -7,11 +7,6 @@ const postMock = mock();
 const createMockClient = (): AppClient => ({
   api: {
     v1: {
-      market: {
-        indicators: { $get: mock() },
-        replay: { $get: mock() },
-        sessions: { $get: mock() },
-      },
       community: {
         threads: {
           $get: mock(),
@@ -20,7 +15,7 @@ const createMockClient = (): AppClient => ({
       },
     },
   },
-});
+} as unknown as AppClient);
 
 describe("createCommunityThread", () => {
   beforeEach(() => {

--- a/apps/frontend/src/features/community/api/createCommunityThread.ts
+++ b/apps/frontend/src/features/community/api/createCommunityThread.ts
@@ -1,11 +1,14 @@
-import { apiClient, type CreateCommunityThreadInput } from "@/lib/api/client";
+import { apiClient, type AppClient, type CreateCommunityThreadInput } from "@/lib/api/client";
 
 /**
  * createCommunityThread は掲示板スレッドを新規作成します。
  * @responsibility 投稿APIの通信結果を検証し、作成済みスレッドを返す。
  */
-export async function createCommunityThread(input: CreateCommunityThreadInput) {
-  const res = await apiClient.api.v1.community.threads.$post(
+export async function createCommunityThread(
+  input: CreateCommunityThreadInput,
+  client: AppClient = apiClient,
+) {
+  const res = await client.api.v1.community.threads.$post(
     { json: input },
     {
       init: {

--- a/apps/frontend/src/features/community/components/CommunityBoard.test.tsx
+++ b/apps/frontend/src/features/community/components/CommunityBoard.test.tsx
@@ -4,9 +4,6 @@ import { ToastProvider } from "@/features/common/components/ToastProvider";
 import { CommunityBoard } from "./CommunityBoard";
 
 const createCommunityThreadMock = mock();
-mock.module("@/features/community/api/createCommunityThread", () => ({
-  createCommunityThread: createCommunityThreadMock,
-}));
 
 describe("CommunityBoard", () => {
   it("投稿作成後、作成済みスレッドを一覧へ先頭追加すること", async () => {
@@ -21,7 +18,7 @@ describe("CommunityBoard", () => {
 
     render(
       <ToastProvider>
-        <CommunityBoard initialThreads={[]} />
+        <CommunityBoard createThread={createCommunityThreadMock} initialThreads={[]} />
       </ToastProvider>,
     );
 

--- a/apps/frontend/src/features/community/components/CommunityBoard.tsx
+++ b/apps/frontend/src/features/community/components/CommunityBoard.tsx
@@ -2,23 +2,25 @@
 
 import { useState } from "react";
 import { CommunityPostForm } from "@/features/community/components/CommunityPostForm";
+import { createCommunityThread } from "@/features/community/api/createCommunityThread";
 import { CommunityThreadList } from "@/features/community/components/CommunityThreadList";
 import type { CommunityThread } from "@/lib/api/client";
 
 type CommunityBoardProps = {
   initialThreads: CommunityThread[];
+  createThread?: typeof createCommunityThread;
 };
 
 /**
  * CommunityBoard は掲示板のクライアント操作をまとめます。
  * @responsibility 初期表示済みの投稿一覧へ、新規作成された投稿を反映する。
  */
-export function CommunityBoard({ initialThreads }: CommunityBoardProps) {
+export function CommunityBoard({ createThread, initialThreads }: CommunityBoardProps) {
   const [threads, setThreads] = useState(initialThreads);
 
   return (
     <div className="grid gap-5">
-      <CommunityPostForm onCreated={(thread) => setThreads((current) => [thread, ...current])} />
+      <CommunityPostForm createThread={createThread} onCreated={(thread) => setThreads((current) => [thread, ...current])} />
       <CommunityThreadList threads={threads} />
     </div>
   );

--- a/apps/frontend/src/features/community/components/CommunityPostForm.test.tsx
+++ b/apps/frontend/src/features/community/components/CommunityPostForm.test.tsx
@@ -4,9 +4,6 @@ import { ToastProvider } from "@/features/common/components/ToastProvider";
 import { CommunityPostForm } from "./CommunityPostForm";
 
 const createCommunityThreadMock = mock();
-mock.module("@/features/community/api/createCommunityThread", () => ({
-  createCommunityThread: createCommunityThreadMock,
-}));
 
 describe("CommunityPostForm", () => {
   beforeEach(() => {
@@ -16,7 +13,7 @@ describe("CommunityPostForm", () => {
   it("必須項目が空の場合、入力エラーを表示すること", async () => {
     render(
       <ToastProvider>
-        <CommunityPostForm onCreated={mock()} />
+        <CommunityPostForm createThread={createCommunityThreadMock} onCreated={mock()} />
       </ToastProvider>,
     );
 
@@ -41,7 +38,7 @@ describe("CommunityPostForm", () => {
 
     render(
       <ToastProvider>
-        <CommunityPostForm onCreated={onCreated} />
+        <CommunityPostForm createThread={createCommunityThreadMock} onCreated={onCreated} />
       </ToastProvider>,
     );
 
@@ -72,7 +69,7 @@ describe("CommunityPostForm", () => {
 
     render(
       <ToastProvider>
-        <CommunityPostForm onCreated={mock()} />
+        <CommunityPostForm createThread={createCommunityThreadMock} onCreated={mock()} />
       </ToastProvider>,
     );
 

--- a/apps/frontend/src/features/community/components/CommunityPostForm.tsx
+++ b/apps/frontend/src/features/community/components/CommunityPostForm.tsx
@@ -19,13 +19,14 @@ type CommunityPostFormValues = z.infer<typeof communityPostSchema>;
 
 type CommunityPostFormProps = {
   onCreated: (thread: CommunityThread) => void;
+  createThread?: typeof createCommunityThread;
 };
 
 /**
  * CommunityPostForm は掲示板の新規投稿フォームです。
  * @responsibility 入力検証、投稿API呼び出し、成功・失敗の通知を担当する。
  */
-export function CommunityPostForm({ onCreated }: CommunityPostFormProps) {
+export function CommunityPostForm({ createThread = createCommunityThread, onCreated }: CommunityPostFormProps) {
   const { showToast } = useToast();
   const {
     formState: { errors, isSubmitting },
@@ -43,7 +44,7 @@ export function CommunityPostForm({ onCreated }: CommunityPostFormProps) {
 
   const onSubmit = handleSubmit(async (values) => {
     try {
-      const thread = await createCommunityThread(values);
+      const thread = await createThread(values);
       onCreated(thread);
       reset();
       showToast({


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #91

# Todo

- [x] `createCommunityThread` のテストを module mock の評価順に依存しない形へ変更
- [x] 通常利用では既存の `apiClient` を使い続ける形で任意 client 注入を追加
- [x] CI と同じ Bun 1.3.13 で失敗箇所のテストを確認

# How to check (動作確認の手順)

```zsh
bun install
bun run lint:all
bun run test:all
bun test apps/frontend/src/features/community/api/createCommunityThread.test.ts
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-06 12:36 (JST)
- ブランチ: codex/fix-develop-ci-community-thread-test

```text
PATH="$HOME/.bun/bin:$PATH" bun run test:all

Frontend: 53 pass, 0 fail
Backend: 92 pass, 0 fail
```

```text
PATH="$HOME/.bun/bin:$PATH" bun run lint:all

frontend eslint: pass
backend eslint: pass
```

```text
/tmp/bun-1.3.13/bun-linux-x64/bun --revision
1.3.13+bf2e2cecf

/tmp/bun-1.3.13/bun-linux-x64/bun test apps/frontend/src/features/community/api/createCommunityThread.test.ts
2 pass, 0 fail
```

</details>

# Related Links

- Failed CI run: https://github.com/somadevfat/gold-bunseki-web/actions/runs/25414676002
