### PR TITLE
[BE] 掲示板の返信APIを実装する

### DIFF
--- a/apps/backend/migrations/0003_adorable_bill_hollister.sql
+++ b/apps/backend/migrations/0003_adorable_bill_hollister.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "community_replies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"thread_id" uuid NOT NULL,
+	"body" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "community_replies" ADD CONSTRAINT "community_replies_thread_id_community_threads_id_fk" FOREIGN KEY ("thread_id") REFERENCES "public"."community_threads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_community_replies_thread_created" ON "community_replies" USING btree ("thread_id","created_at");

--- a/apps/backend/migrations/meta/0003_snapshot.json
+++ b/apps/backend/migrations/meta/0003_snapshot.json
@@ -1,0 +1,856 @@
+{
+  "id": "289b3d01-5f22-4f24-965b-8bdb17aa6ed9",
+  "prevId": "ba33b2f3-9f78-4204-8fc3-1abbb3bbd945",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_replies": {
+      "name": "community_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_community_replies_thread_created": {
+          "name": "idx_community_replies_thread_created",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_replies_thread_id_community_threads_id_fk": {
+          "name": "community_replies_thread_id_community_threads_id_fk",
+          "tableFrom": "community_replies",
+          "tableTo": "community_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_threads": {
+      "name": "community_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'General'"
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.economic_events": {
+      "name": "economic_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "economic_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "datetime_jst": {
+          "name": "datetime_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual": {
+          "name": "actual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forecast": {
+          "name": "forecast",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous": {
+          "name": "previous",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_name_datetime": {
+          "name": "idx_events_name_datetime",
+          "columns": [
+            {
+              "expression": "datetime_jst",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_candles": {
+      "name": "price_candles",
+      "schema": "",
+      "columns": {
+        "datetime_jst": {
+          "name": "datetime_jst",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_price": {
+          "name": "open_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_price": {
+          "name": "high_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low_price": {
+          "name": "low_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_price": {
+          "name": "close_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "open": {
+          "name": "open",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high": {
+          "name": "high",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low": {
+          "name": "low",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close": {
+          "name": "close",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_thresholds": {
+      "name": "session_thresholds",
+      "schema": "",
+      "columns": {
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "small_threshold": {
+          "name": "small_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "large_threshold": {
+          "name": "large_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_volatilities": {
+      "name": "session_volatilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "session_volatilities_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time_jst": {
+          "name": "start_time_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time_jst": {
+          "name": "end_time_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volatility_points": {
+          "name": "volatility_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_event": {
+          "name": "has_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_high_impact_event": {
+          "name": "has_high_impact_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "events_linked": {
+          "name": "events_linked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_session_date_name": {
+          "name": "idx_session_date_name",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_candle_at": {
+          "name": "last_candle_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_session_at": {
+          "name": "last_session_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_candles": {
+          "name": "total_candles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_health": {
+          "name": "sync_health",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Healthy'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zigzag_points": {
+      "name": "zigzag_points",
+      "schema": "",
+      "columns": {
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777609634396,
       "tag": "0002_romantic_captain_marvel",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778073129485,
+      "tag": "0003_adorable_bill_hollister",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import { CalculateZigZagUseCase } from '../application/use_case/calculateZigZagUseCase';
+import { CreateCommunityReplyUseCase } from '../application/use_case/createCommunityReplyUseCase';
 import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
+import { GetCommunityThreadDetailUseCase } from '../application/use_case/getCommunityThreadDetailUseCase';
 import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
 import { GetLatestPriceUseCase } from '../application/use_case/getLatestPriceUseCase';
 import { GetRecentEventNamesUseCase } from '../application/use_case/getRecentEventNamesUseCase';
@@ -18,7 +20,9 @@ describe('createAppContainer', () => {
     expect(container.repositories.priceRepo).toBeDefined();
     expect(container.repositories.syncRepo).toBeDefined();
     expect(container.useCases.community.getThreads).toBeInstanceOf(GetCommunityThreadsUseCase);
+    expect(container.useCases.community.getThreadDetail).toBeInstanceOf(GetCommunityThreadDetailUseCase);
     expect(container.useCases.community.createThread).toBeInstanceOf(CreateCommunityThreadUseCase);
+    expect(container.useCases.community.createReply).toBeInstanceOf(CreateCommunityReplyUseCase);
     expect(container.useCases.sync.getStatus).toBeInstanceOf(GetSyncStatusUseCase);
     expect(container.useCases.market.getLatestPrice).toBeInstanceOf(GetLatestPriceUseCase);
     expect(container.useCases.market.calculateZigZag).toBeInstanceOf(CalculateZigZagUseCase);

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -1,5 +1,7 @@
 import { CalculateZigZagUseCase } from "../application/use_case/calculateZigZagUseCase";
+import { CreateCommunityReplyUseCase } from "../application/use_case/createCommunityReplyUseCase";
 import { CreateCommunityThreadUseCase } from "../application/use_case/createCommunityThreadUseCase";
+import { GetCommunityThreadDetailUseCase } from "../application/use_case/getCommunityThreadDetailUseCase";
 import { GetCommunityThreadsUseCase } from "../application/use_case/getCommunityThreadsUseCase";
 import { GetLatestPriceUseCase } from "../application/use_case/getLatestPriceUseCase";
 import { GetRecentEventNamesUseCase } from "../application/use_case/getRecentEventNamesUseCase";
@@ -58,7 +60,9 @@ export function createAppContainer(
     useCases: {
       community: {
         getThreads: new GetCommunityThreadsUseCase(communityThreadRepo),
+        getThreadDetail: new GetCommunityThreadDetailUseCase(communityThreadRepo),
         createThread: new CreateCommunityThreadUseCase(communityThreadRepo),
+        createReply: new CreateCommunityReplyUseCase(communityThreadRepo),
       },
       sync: {
         getStatus: new GetSyncStatusUseCase(syncRepo),

--- a/apps/backend/src/application/port/communityThreadRepositoryPort.ts
+++ b/apps/backend/src/application/port/communityThreadRepositoryPort.ts
@@ -1,4 +1,9 @@
-import { CommunityThread, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+import {
+  CommunityReply,
+  CommunityThread,
+  CreateCommunityReplyInput,
+  CreateCommunityThreadInput,
+} from '../../domain/entities/communityThread';
 
 /**
  * CommunityThreadRepositoryPort は掲示板スレッドを管理するリポジトリインターフェースです。
@@ -11,7 +16,22 @@ export interface CommunityThreadRepositoryPort {
   findAll(limit: number): Promise<CommunityThread[]>;
 
   /**
+   * IDを指定して掲示板スレッドを取得します。
+   */
+  findById(threadId: string): Promise<CommunityThread | null>;
+
+  /**
+   * 指定したスレッドの返信一覧を古い順で取得します。
+   */
+  findReplies(threadId: string): Promise<CommunityReply[]>;
+
+  /**
    * 新規スレッドを作成して返します。
    */
   create(input: CreateCommunityThreadInput): Promise<CommunityThread>;
+
+  /**
+   * 指定したスレッドへ返信を作成して返します。
+   */
+  createReply(threadId: string, input: CreateCommunityReplyInput): Promise<CommunityReply>;
 }

--- a/apps/backend/src/application/use_case/createCommunityReplyUseCase.ts
+++ b/apps/backend/src/application/use_case/createCommunityReplyUseCase.ts
@@ -1,0 +1,20 @@
+import { CommunityThreadRepositoryPort } from '../port/communityThreadRepositoryPort';
+import { CommunityReply, CreateCommunityReplyInput } from '../../domain/entities/communityThread';
+
+/**
+ * CreateCommunityReplyUseCase は掲示板スレッドへの返信を作成するユースケースです。
+ * @responsibility: 対象スレッドの存在確認後、返信を永続化する。
+ */
+export class CreateCommunityReplyUseCase {
+  constructor(private readonly repo: CommunityThreadRepositoryPort) {}
+
+  async execute(threadId: string, input: CreateCommunityReplyInput): Promise<CommunityReply | null> {
+    const thread = await this.repo.findById(threadId);
+
+    if (!thread) {
+      return null;
+    }
+
+    return this.repo.createReply(threadId, input);
+  }
+}

--- a/apps/backend/src/application/use_case/getCommunityThreadDetailUseCase.ts
+++ b/apps/backend/src/application/use_case/getCommunityThreadDetailUseCase.ts
@@ -1,0 +1,25 @@
+import { CommunityThreadRepositoryPort } from '../port/communityThreadRepositoryPort';
+import { CommunityThreadDetail } from '../../domain/entities/communityThread';
+
+/**
+ * GetCommunityThreadDetailUseCase は掲示板スレッド詳細と返信一覧を取得するユースケースです。
+ * @responsibility: スレッド本文と返信一覧をリポジトリから集約して返す。
+ */
+export class GetCommunityThreadDetailUseCase {
+  constructor(private readonly repo: CommunityThreadRepositoryPort) {}
+
+  async execute(threadId: string): Promise<CommunityThreadDetail | null> {
+    const thread = await this.repo.findById(threadId);
+
+    if (!thread) {
+      return null;
+    }
+
+    const replies = await this.repo.findReplies(threadId);
+
+    return {
+      thread,
+      replies,
+    };
+  }
+}

--- a/apps/backend/src/application/use_case/test/createCommunityReplyUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/createCommunityReplyUseCase.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { CreateCommunityReplyUseCase } from '../createCommunityReplyUseCase';
+import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
+import { CommunityReply, CommunityThread, CreateCommunityReplyInput } from '../../../domain/entities/communityThread';
+
+const mockThread: CommunityThread = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前後のXAUUSDの値幅について',
+  body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+  category: 'Market Discussion',
+  replyCount: 0,
+  createdAt: '2026-04-01T12:00:00.000Z',
+};
+
+const mockReply: CommunityReply = {
+  id: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  threadId: mockThread.id,
+  body: 'NY後半の戻りを見る観点に同意です。',
+  createdAt: '2026-04-01T12:30:00.000Z',
+};
+
+const input: CreateCommunityReplyInput = {
+  body: 'NY後半の戻りを見る観点に同意です。',
+};
+
+function createMockRepo(overrides: Partial<CommunityThreadRepositoryPort> = {}): CommunityThreadRepositoryPort {
+  return {
+    findAll: mock(() => Promise.resolve([mockThread])),
+    findById: mock(() => Promise.resolve(mockThread)),
+    findReplies: mock(() => Promise.resolve([mockReply])),
+    create: mock(() => Promise.resolve(mockThread)),
+    createReply: mock(() => Promise.resolve(mockReply)),
+    ...overrides,
+  };
+}
+
+describe('CreateCommunityReplyUseCase', () => {
+  it('スレッドが存在する場合、返信を作成して返すこと', async () => {
+    const createReply = mock(() => Promise.resolve(mockReply));
+    const repo = createMockRepo({ createReply });
+    const useCase = new CreateCommunityReplyUseCase(repo);
+
+    const result = await useCase.execute(mockThread.id, input);
+
+    expect(result?.id).toBe(mockReply.id);
+    expect(createReply).toHaveBeenCalledWith(mockThread.id, input);
+  });
+
+  it('スレッドが存在しない場合 null を返し、返信を作成しないこと', async () => {
+    const createReply = mock(() => Promise.resolve(mockReply));
+    const repo = createMockRepo({
+      findById: mock(() => Promise.resolve(null)),
+      createReply,
+    });
+    const useCase = new CreateCommunityReplyUseCase(repo);
+
+    const result = await useCase.execute(mockThread.id, input);
+
+    expect(result).toBeNull();
+    expect(createReply).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use_case/test/createCommunityThreadUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/createCommunityThreadUseCase.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, mock } from 'bun:test';
 import { CreateCommunityThreadUseCase } from '../createCommunityThreadUseCase';
 import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
-import { CommunityThread, CreateCommunityThreadInput } from '../../../domain/entities/communityThread';
+import { CommunityReply, CommunityThread, CreateCommunityThreadInput } from '../../../domain/entities/communityThread';
 
 /**
  * CreateCommunityThreadUseCase Unit Tests
@@ -23,14 +23,27 @@ describe('CreateCommunityThreadUseCase (Unit Tests)', () => {
     category: 'Market Discussion',
   };
 
+  const mockReply: CommunityReply = {
+    id: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    threadId: mockCreated.id,
+    body: '同じ観点で見ています。',
+    createdAt: '2026-04-10T09:30:00.000Z',
+  };
+
+  const createMockRepo = (overrides: Partial<CommunityThreadRepositoryPort> = {}): CommunityThreadRepositoryPort => ({
+    findAll: mock(() => Promise.resolve([])),
+    findById: mock(() => Promise.resolve(mockCreated)),
+    findReplies: mock(() => Promise.resolve([mockReply])),
+    create: mock(() => Promise.resolve(mockCreated)),
+    createReply: mock(() => Promise.resolve(mockReply)),
+    ...overrides,
+  });
+
   describe('正常系', () => {
     it('入力を渡してリポジトリの create を呼び出し、作成されたスレッドを返すこと', async () => {
       // ## Arrange ##
       const createMock = mock(() => Promise.resolve(mockCreated));
-      const mockRepo: CommunityThreadRepositoryPort = {
-        findAll: mock(() => Promise.resolve([])),
-        create: createMock,
-      };
+      const mockRepo = createMockRepo({ create: createMock });
       const useCase = new CreateCommunityThreadUseCase(mockRepo);
 
       // ## Act ##
@@ -47,10 +60,9 @@ describe('CreateCommunityThreadUseCase (Unit Tests)', () => {
   describe('異常系', () => {
     it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
       // ## Arrange ##
-      const mockRepo: CommunityThreadRepositoryPort = {
-        findAll: mock(() => Promise.resolve([])),
+      const mockRepo = createMockRepo({
         create: mock(() => Promise.reject(new Error('INSERT失敗'))),
-      };
+      });
       const useCase = new CreateCommunityThreadUseCase(mockRepo);
 
       // ## Act & Assert ##

--- a/apps/backend/src/application/use_case/test/getCommunityThreadDetailUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/getCommunityThreadDetailUseCase.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { GetCommunityThreadDetailUseCase } from '../getCommunityThreadDetailUseCase';
+import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
+import { CommunityReply, CommunityThread } from '../../../domain/entities/communityThread';
+
+const mockThread: CommunityThread = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前後のXAUUSDの値幅について',
+  body: '前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。',
+  category: 'Market Discussion',
+  replyCount: 1,
+  createdAt: '2026-04-01T12:00:00.000Z',
+};
+
+const mockReply: CommunityReply = {
+  id: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  threadId: mockThread.id,
+  body: 'NY後半の戻りを見る観点に同意です。',
+  createdAt: '2026-04-01T12:30:00.000Z',
+};
+
+function createMockRepo(overrides: Partial<CommunityThreadRepositoryPort> = {}): CommunityThreadRepositoryPort {
+  return {
+    findAll: mock(() => Promise.resolve([mockThread])),
+    findById: mock(() => Promise.resolve(mockThread)),
+    findReplies: mock(() => Promise.resolve([mockReply])),
+    create: mock(() => Promise.resolve(mockThread)),
+    createReply: mock(() => Promise.resolve(mockReply)),
+    ...overrides,
+  };
+}
+
+describe('GetCommunityThreadDetailUseCase', () => {
+  it('スレッドと返信一覧をまとめて返すこと', async () => {
+    const repo = createMockRepo();
+    const useCase = new GetCommunityThreadDetailUseCase(repo);
+
+    const result = await useCase.execute(mockThread.id);
+
+    expect(result?.thread.id).toBe(mockThread.id);
+    expect(result?.replies).toHaveLength(1);
+    expect(repo.findReplies).toHaveBeenCalledWith(mockThread.id);
+  });
+
+  it('スレッドが存在しない場合 null を返し、返信一覧を取得しないこと', async () => {
+    const findReplies = mock(() => Promise.resolve([mockReply]));
+    const repo = createMockRepo({
+      findById: mock(() => Promise.resolve(null)),
+      findReplies,
+    });
+    const useCase = new GetCommunityThreadDetailUseCase(repo);
+
+    const result = await useCase.execute(mockThread.id);
+
+    expect(result).toBeNull();
+    expect(findReplies).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use_case/test/getCommunityThreadsUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/getCommunityThreadsUseCase.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, mock } from 'bun:test';
 import { GetCommunityThreadsUseCase } from '../getCommunityThreadsUseCase';
 import { CommunityThreadRepositoryPort } from '../../port/communityThreadRepositoryPort';
-import { CommunityThread } from '../../../domain/entities/communityThread';
+import { CommunityReply, CommunityThread } from '../../../domain/entities/communityThread';
 
 /**
  * GetCommunityThreadsUseCase Unit Tests
@@ -17,13 +17,26 @@ describe('GetCommunityThreadsUseCase (Unit Tests)', () => {
     createdAt: '2026-04-01T12:00:00.000Z',
   };
 
+  const mockReply: CommunityReply = {
+    id: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    threadId: mockThread.id,
+    body: '同じ観点で見ています。',
+    createdAt: '2026-04-01T12:30:00.000Z',
+  };
+
+  const createMockRepo = (overrides: Partial<CommunityThreadRepositoryPort> = {}): CommunityThreadRepositoryPort => ({
+    findAll: mock(() => Promise.resolve([mockThread])),
+    findById: mock(() => Promise.resolve(mockThread)),
+    findReplies: mock(() => Promise.resolve([mockReply])),
+    create: mock(() => Promise.resolve(mockThread)),
+    createReply: mock(() => Promise.resolve(mockReply)),
+    ...overrides,
+  });
+
   describe('正常系', () => {
     it('リポジトリが返したスレッド一覧をそのまま返すこと', async () => {
       // ## Arrange ##
-      const mockRepo: CommunityThreadRepositoryPort = {
-        findAll: mock(() => Promise.resolve([mockThread])),
-        create: mock(() => Promise.resolve(mockThread)),
-      };
+      const mockRepo = createMockRepo();
       const useCase = new GetCommunityThreadsUseCase(mockRepo);
 
       // ## Act ##
@@ -37,10 +50,7 @@ describe('GetCommunityThreadsUseCase (Unit Tests)', () => {
 
     it('リポジトリが空配列を返した場合、空配列を返すこと', async () => {
       // ## Arrange ##
-      const mockRepo: CommunityThreadRepositoryPort = {
-        findAll: mock(() => Promise.resolve([])),
-        create: mock(() => Promise.resolve(mockThread)),
-      };
+      const mockRepo = createMockRepo({ findAll: mock(() => Promise.resolve([])) });
       const useCase = new GetCommunityThreadsUseCase(mockRepo);
 
       // ## Act ##
@@ -53,10 +63,7 @@ describe('GetCommunityThreadsUseCase (Unit Tests)', () => {
     it('デフォルト limit (50) で findAll を呼び出すこと', async () => {
       // ## Arrange ##
       const findAllMock = mock(() => Promise.resolve([mockThread]));
-      const mockRepo: CommunityThreadRepositoryPort = {
-        findAll: findAllMock,
-        create: mock(() => Promise.resolve(mockThread)),
-      };
+      const mockRepo = createMockRepo({ findAll: findAllMock });
       const useCase = new GetCommunityThreadsUseCase(mockRepo);
 
       // ## Act ##
@@ -70,10 +77,9 @@ describe('GetCommunityThreadsUseCase (Unit Tests)', () => {
   describe('異常系', () => {
     it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
       // ## Arrange ##
-      const mockRepo: CommunityThreadRepositoryPort = {
+      const mockRepo = createMockRepo({
         findAll: mock(() => Promise.reject(new Error('DB接続エラー'))),
-        create: mock(() => Promise.resolve(mockThread)),
-      };
+      });
       const useCase = new GetCommunityThreadsUseCase(mockRepo);
 
       // ## Act & Assert ##

--- a/apps/backend/src/domain/entities/communityThread.ts
+++ b/apps/backend/src/domain/entities/communityThread.ts
@@ -16,6 +16,30 @@ export const CommunityThreadSchema = z.object({
 export type CommunityThread = z.infer<typeof CommunityThreadSchema>;
 
 /**
+ * CommunityReplySchema は掲示板スレッドへの返信を表すドメインスキーマです。
+ * @responsibility: 返信本文・紐付くスレッドID・作成日時を保持する。
+ */
+export const CommunityReplySchema = z.object({
+  id: z.string().uuid().openapi({ example: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890', description: '返信ID' }),
+  threadId: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', description: 'スレッドID' }),
+  body: z.string().min(1).max(5000).openapi({ example: '発表直後よりNY後半の戻りを重視しています。', description: '返信本文' }),
+  createdAt: z.string().datetime().openapi({ example: '2026-04-01T12:30:00.000Z', description: '作成日時（ISO 8601）' }),
+}).openapi('CommunityReply');
+
+export type CommunityReply = z.infer<typeof CommunityReplySchema>;
+
+/**
+ * CommunityThreadDetailSchema はスレッド詳細と返信一覧のレスポンススキーマです。
+ * @responsibility: スレッド本文と紐付く返信一覧をまとめて返す。
+ */
+export const CommunityThreadDetailSchema = z.object({
+  thread: CommunityThreadSchema,
+  replies: z.array(CommunityReplySchema),
+}).openapi('CommunityThreadDetail');
+
+export type CommunityThreadDetail = z.infer<typeof CommunityThreadDetailSchema>;
+
+/**
  * CreateCommunityThreadInputSchema は新規スレッド作成時のバリデーションスキーマです。
  * @responsibility: タイトル・本文・カテゴリの基本バリデーションを行う。
  */
@@ -38,3 +62,17 @@ export const CreateCommunityThreadInputSchema = z.object({
 }).openapi('CreateCommunityThreadInput');
 
 export type CreateCommunityThreadInput = z.infer<typeof CreateCommunityThreadInputSchema>;
+
+/**
+ * CreateCommunityReplyInputSchema は新規返信作成時のバリデーションスキーマです。
+ * @responsibility: 返信本文の基本バリデーションを行う。
+ */
+export const CreateCommunityReplyInputSchema = z.object({
+  body: z
+    .string()
+    .min(1, '本文は1文字以上で入力してください')
+    .max(5000, '本文は5000文字以内で入力してください')
+    .openapi({ example: '発表直後よりNY後半の戻りを重視しています。', description: '返信本文' }),
+}).openapi('CreateCommunityReplyInput');
+
+export type CreateCommunityReplyInput = z.infer<typeof CreateCommunityReplyInputSchema>;

--- a/apps/backend/src/infrastructure/database/schema.ts
+++ b/apps/backend/src/infrastructure/database/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, real, integer, boolean, uniqueIndex, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { pgTable, text, real, integer, boolean, uniqueIndex, timestamp, uuid, index } from 'drizzle-orm/pg-core';
 
 export const prices = pgTable('prices', {
   timestamp: text('timestamp').primaryKey(),
@@ -78,6 +78,16 @@ export const communityThreads = pgTable('community_threads', {
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
 
+export const communityReplies = pgTable('community_replies', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  threadId: uuid('thread_id').notNull().references(() => communityThreads.id, { onDelete: 'cascade' }),
+  body: text('body').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (table) => [
+  index('idx_community_replies_thread_created').on(table.threadId, table.createdAt),
+]);
+
 // ==========================================
 // Better Auth Core Tables
 // ==========================================
@@ -127,4 +137,3 @@ export const verification = pgTable("verification", {
 	createdAt: timestamp('createdAt'),
 	updatedAt: timestamp('updatedAt')
 });
-

--- a/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
+++ b/apps/backend/src/infrastructure/repository/drizzleCommunityThreadRepository.ts
@@ -1,8 +1,13 @@
 import { CommunityThreadRepositoryPort } from '../../application/port/communityThreadRepositoryPort';
-import { CommunityThread, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+import {
+  CommunityReply,
+  CommunityThread,
+  CreateCommunityReplyInput,
+  CreateCommunityThreadInput,
+} from '../../domain/entities/communityThread';
 import { DbType } from '../database/db';
-import { communityThreads } from '../database/schema';
-import { desc } from 'drizzle-orm';
+import { communityReplies, communityThreads } from '../database/schema';
+import { asc, desc, eq, sql } from 'drizzle-orm';
 
 /**
  * DrizzleCommunityThreadRepository は PostgreSQL (Drizzle) を使用した掲示板スレッドのリポジトリ実装です。
@@ -10,6 +15,26 @@ import { desc } from 'drizzle-orm';
  */
 export class DrizzleCommunityThreadRepository implements CommunityThreadRepositoryPort {
   constructor(private readonly db: DbType) {}
+
+  private mapThread(row: typeof communityThreads.$inferSelect): CommunityThread {
+    return {
+      id: row.id,
+      title: row.title,
+      body: row.body,
+      category: row.category,
+      replyCount: row.replyCount,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+
+  private mapReply(row: typeof communityReplies.$inferSelect): CommunityReply {
+    return {
+      id: row.id,
+      threadId: row.threadId,
+      body: row.body,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
 
   /**
    * findAll は掲示板スレッドを新しい順で取得します。
@@ -21,14 +46,33 @@ export class DrizzleCommunityThreadRepository implements CommunityThreadReposito
       .orderBy(desc(communityThreads.createdAt))
       .limit(limit);
 
-    return rows.map((r) => ({
-      id: r.id,
-      title: r.title,
-      body: r.body,
-      category: r.category,
-      replyCount: r.replyCount,
-      createdAt: r.createdAt.toISOString(),
-    }));
+    return rows.map((row) => this.mapThread(row));
+  }
+
+  /**
+   * findById は指定したIDの掲示板スレッドを取得します。
+   */
+  async findById(threadId: string): Promise<CommunityThread | null> {
+    const rows = await this.db
+      .select()
+      .from(communityThreads)
+      .where(eq(communityThreads.id, threadId))
+      .limit(1);
+
+    return rows[0] ? this.mapThread(rows[0]) : null;
+  }
+
+  /**
+   * findReplies は指定したスレッドの返信を古い順で取得します。
+   */
+  async findReplies(threadId: string): Promise<CommunityReply[]> {
+    const rows = await this.db
+      .select()
+      .from(communityReplies)
+      .where(eq(communityReplies.threadId, threadId))
+      .orderBy(asc(communityReplies.createdAt));
+
+    return rows.map((row) => this.mapReply(row));
   }
 
   /**
@@ -44,13 +88,33 @@ export class DrizzleCommunityThreadRepository implements CommunityThreadReposito
       })
       .returning();
 
-    return {
-      id: row.id,
-      title: row.title,
-      body: row.body,
-      category: row.category,
-      replyCount: row.replyCount,
-      createdAt: row.createdAt.toISOString(),
-    };
+    return this.mapThread(row);
+  }
+
+  /**
+   * createReply は返信作成とスレッドの返信数更新を同一トランザクションで行います。
+   */
+  async createReply(threadId: string, input: CreateCommunityReplyInput): Promise<CommunityReply> {
+    const row = await this.db.transaction(async (tx) => {
+      const [reply] = await tx
+        .insert(communityReplies)
+        .values({
+          threadId,
+          body: input.body,
+        })
+        .returning();
+
+      await tx
+        .update(communityThreads)
+        .set({
+          replyCount: sql`${communityThreads.replyCount} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(eq(communityThreads.id, threadId));
+
+      return reply;
+    });
+
+    return this.mapReply(row);
   }
 }

--- a/apps/backend/src/interface/controller/communityController.ts
+++ b/apps/backend/src/interface/controller/communityController.ts
@@ -1,6 +1,6 @@
 import { Context } from 'hono';
 import { Bindings, AppVariables } from '../types';
-import { CreateCommunityThreadInput } from '../../domain/entities/communityThread';
+import { CreateCommunityReplyInput, CreateCommunityThreadInput } from '../../domain/entities/communityThread';
 import { AppContainer } from '../../app/container';
 
 /**
@@ -26,6 +26,37 @@ export function createCommunityController(container: AppContainer) {
       const input = (await c.req.valid('json' as never)) as CreateCommunityThreadInput;
       const thread = await container.useCases.community.createThread.execute(input);
       return c.json(thread, 201);
+    },
+
+    /**
+     * スレッド詳細の取得
+     * @responsibility スレッド本文と返信一覧を JSON 形式で返す。
+     */
+    getThreadDetail: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const { threadId } = (await c.req.valid('param' as never)) as { threadId: string };
+      const detail = await container.useCases.community.getThreadDetail.execute(threadId);
+
+      if (!detail) {
+        return c.json({ message: 'スレッドが見つかりません' }, 404);
+      }
+
+      return c.json(detail, 200);
+    },
+
+    /**
+     * スレッド返信の新規作成
+     * @responsibility リクエストボディをバリデーションし、返信作成ユースケースを実行する。
+     */
+    createReply: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const { threadId } = (await c.req.valid('param' as never)) as { threadId: string };
+      const input = (await c.req.valid('json' as never)) as CreateCommunityReplyInput;
+      const reply = await container.useCases.community.createReply.execute(threadId, input);
+
+      if (!reply) {
+        return c.json({ message: 'スレッドが見つかりません' }, 404);
+      }
+
+      return c.json(reply, 201);
     },
   };
 }

--- a/apps/backend/src/interface/controller/test/communityController.test.ts
+++ b/apps/backend/src/interface/controller/test/communityController.test.ts
@@ -1,14 +1,17 @@
 import { expect, describe, it, mock, beforeEach } from 'bun:test';
 import { createCommunityController } from '../communityController';
 import { createMockContext } from '../../test/testHelpers';
-import { CommunityThread } from '../../../domain/entities/communityThread';
+import { CommunityReply, CommunityThread } from '../../../domain/entities/communityThread';
 import { AppContainer } from '../../../app/container';
 
 interface MockResponse {
   body: Record<string, unknown> & {
     threads?: CommunityThread[];
+    thread?: CommunityThread;
+    replies?: CommunityReply[];
     id?: string;
     title?: string;
+    message?: string;
   };
   status: number;
 }
@@ -22,6 +25,13 @@ const mockThread: CommunityThread = {
   createdAt: '2026-04-01T12:00:00.000Z',
 };
 
+const mockReply: CommunityReply = {
+  id: 'b1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  threadId: mockThread.id,
+  body: 'NY後半の戻りを見る観点に同意です。',
+  createdAt: '2026-04-01T12:30:00.000Z',
+};
+
 /**
  * CommunityController Unit Tests
  * @responsibility: 掲示板スレッドの一覧取得・作成APIの正常系・異常系を検証する。
@@ -30,15 +40,21 @@ describe('CommunityController', () => {
   let container: AppContainer;
   let getThreadsExecute: ReturnType<typeof mock>;
   let createThreadExecute: ReturnType<typeof mock>;
+  let getThreadDetailExecute: ReturnType<typeof mock>;
+  let createReplyExecute: ReturnType<typeof mock>;
 
   beforeEach(() => {
     getThreadsExecute = mock(() => Promise.resolve([mockThread]));
     createThreadExecute = mock(() => Promise.resolve(mockThread));
+    getThreadDetailExecute = mock(() => Promise.resolve({ thread: mockThread, replies: [mockReply] }));
+    createReplyExecute = mock(() => Promise.resolve(mockReply));
     container = {
       useCases: {
         community: {
           getThreads: { execute: getThreadsExecute },
+          getThreadDetail: { execute: getThreadDetailExecute },
           createThread: { execute: createThreadExecute },
+          createReply: { execute: createReplyExecute },
         },
       },
     } as unknown as AppContainer;
@@ -128,6 +144,78 @@ describe('CommunityController', () => {
 
       // ## Act & Assert ##
       await expect(controller.createThread(c)).rejects.toThrow('INSERT失敗');
+    });
+  });
+
+  // ==========================================
+  // getThreadDetail
+  // ==========================================
+  describe('getThreadDetail', () => {
+    it('スレッド詳細と返信一覧を取得して 200 を返すこと', async () => {
+      // ## Arrange ##
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, { threadId: mockThread.id });
+
+      // ## Act ##
+      const res = (await controller.getThreadDetail(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.thread?.id).toBe(mockThread.id);
+      expect(res.body.replies).toHaveLength(1);
+      expect(getThreadDetailExecute).toHaveBeenCalledWith(mockThread.id);
+    });
+
+    it('スレッドが存在しない場合 404 を返すこと', async () => {
+      // ## Arrange ##
+      getThreadDetailExecute = mock(() => Promise.resolve(null));
+      container.useCases.community.getThreadDetail.execute = getThreadDetailExecute;
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, { threadId: mockThread.id });
+
+      // ## Act ##
+      const res = (await controller.getThreadDetail(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('スレッドが見つかりません');
+    });
+  });
+
+  // ==========================================
+  // createReply
+  // ==========================================
+  describe('createReply', () => {
+    it('有効な入力で返信を作成して 201 を返すこと', async () => {
+      // ## Arrange ##
+      const body = {
+        body: 'NY後半の戻りを見る観点に同意です。',
+      };
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, { threadId: mockThread.id }, body);
+
+      // ## Act ##
+      const res = (await controller.createReply(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe(mockReply.id);
+      expect(createReplyExecute).toHaveBeenCalledWith(mockThread.id, body);
+    });
+
+    it('スレッドが存在しない場合 404 を返すこと', async () => {
+      // ## Arrange ##
+      createReplyExecute = mock(() => Promise.resolve(null));
+      container.useCases.community.createReply.execute = createReplyExecute;
+      const controller = createCommunityController(container);
+      const c = createMockContext({}, {}, { threadId: mockThread.id }, { body: '本文です。' });
+
+      // ## Act ##
+      const res = (await controller.createReply(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('スレッドが見つかりません');
     });
   });
 });

--- a/apps/backend/src/interface/routes/communityRoutes.ts
+++ b/apps/backend/src/interface/routes/communityRoutes.ts
@@ -2,7 +2,12 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import { AppContainer } from '../../app/container';
 import { createCommunityController } from '../controller/communityController';
 import { AppVariables, Bindings } from '../types';
-import { communityThreadsRoute, createCommunityThreadRoute } from './openapi';
+import {
+  communityThreadDetailRoute,
+  communityThreadsRoute,
+  createCommunityReplyRoute,
+  createCommunityThreadRoute,
+} from './openapi';
 
 type BackendApp = OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>;
 
@@ -15,4 +20,6 @@ export function registerCommunityRoutes(app: BackendApp, container: AppContainer
 
   app.openapi(communityThreadsRoute, controller.getThreads);
   app.openapi(createCommunityThreadRoute, controller.createThread);
+  app.openapi(communityThreadDetailRoute, controller.getThreadDetail);
+  app.openapi(createCommunityReplyRoute, controller.createReply);
 }

--- a/apps/backend/src/interface/routes/openapi.ts
+++ b/apps/backend/src/interface/routes/openapi.ts
@@ -4,7 +4,13 @@ import { ZigZagPointSchema } from "../../domain/entities/zigzag";
 import { SessionVolatilitySchema } from "../../domain/entities/session";
 import { SyncStatusSchema } from "../../domain/entities/syncStatus";
 import { ReplayDataResponseSchema } from "../../domain/entities/replay";
-import { CommunityThreadSchema, CreateCommunityThreadInputSchema } from "../../domain/entities/communityThread";
+import {
+  CommunityReplySchema,
+  CommunityThreadDetailSchema,
+  CommunityThreadSchema,
+  CreateCommunityReplyInputSchema,
+  CreateCommunityThreadInputSchema,
+} from "../../domain/entities/communityThread";
 
 /**
  * Health Check ルート
@@ -288,6 +294,82 @@ export const createCommunityThreadRoute = createRoute({
 });
 
 /**
+ * 掲示板スレッド詳細ルート
+ */
+export const communityThreadDetailRoute = createRoute({
+  method: "get",
+  path: "/api/v1/community/threads/{threadId}",
+  request: {
+    params: z.object({
+      threadId: z.string().uuid().openapi({
+        param: { name: "threadId", in: "path" },
+        example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        description: "スレッドID",
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: CommunityThreadDetailSchema,
+        },
+      },
+      description: "掲示板スレッド詳細と返信一覧を取得します",
+    },
+    404: {
+      description: "スレッドが見つかりません",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * 掲示板返信作成ルート
+ */
+export const createCommunityReplyRoute = createRoute({
+  method: "post",
+  path: "/api/v1/community/threads/{threadId}/replies",
+  request: {
+    params: z.object({
+      threadId: z.string().uuid().openapi({
+        param: { name: "threadId", in: "path" },
+        example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        description: "スレッドID",
+      }),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateCommunityReplyInputSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: CommunityReplySchema,
+        },
+      },
+      description: "掲示板返信を作成して返します",
+    },
+    400: {
+      description: "バリデーションエラー",
+    },
+    404: {
+      description: "スレッドが見つかりません",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
  * データ同期(Push)受取 - シード用 (過去数年分の一括同期など)
  */
 export const syncSeedRoute = createRoute({
@@ -319,4 +401,3 @@ export const syncSeedRoute = createRoute({
     }
   },
 });
-

--- a/apps/backend/src/interface/test/testHelpers.ts
+++ b/apps/backend/src/interface/test/testHelpers.ts
@@ -11,7 +11,10 @@ type MockQueryBuilder = {
   limit: ReturnType<typeof mock>;
   groupBy: ReturnType<typeof mock>;
   insert: ReturnType<typeof mock>;
+  update: ReturnType<typeof mock>;
   values: ReturnType<typeof mock>;
+  set: ReturnType<typeof mock>;
+  returning: ReturnType<typeof mock>;
   onConflictDoNothing: ReturnType<typeof mock>;
   onConflictDoUpdate: ReturnType<typeof mock>;
   transaction: ReturnType<typeof mock>;
@@ -31,7 +34,10 @@ export const createMockDrizzle = <T = unknown>(results: T[] = []) => {
     limit: mock(() => queryMock),
     groupBy: mock(() => queryMock),
     insert: mock(() => queryMock),
+    update: mock(() => queryMock),
     values: mock(() => queryMock),
+    set: mock(() => queryMock),
+    returning: mock(() => queryMock),
     onConflictDoNothing: mock(() => queryMock),
     onConflictDoUpdate: mock(() => queryMock),
     transaction: mock((cb: (db: unknown) => Promise<unknown>) => cb(queryMock)),


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #31

# Todo

- [x] 返信データのEntity/型を追加
- [x] スレッド詳細取得APIで返信一覧を返す
- [x] 返信作成APIを追加
- [x] 本文の基本バリデーションを追加
- [x] 正常系・異常系の単体テストを追加/更新
- [x] `community_replies` migration を追加

# How to check (動作確認の手順)

```zsh
bun install
bun run lint:all
bun run test:all
cd apps/backend && bunx tsc --noEmit
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-06 22:16 (JST)
- ブランチ: codex/issue-31-community-replies-api

```text
PATH="$HOME/.bun/bin:$PATH" bun run lint:all
frontend eslint: pass
backend eslint: pass
```

```text
PATH="$HOME/.bun/bin:$PATH" bun run test:all
Frontend: 53 pass, 0 fail
Backend: 100 pass, 0 fail
```

```text
cd apps/backend && PATH="$HOME/.bun/bin:$PATH" bunx tsc --noEmit
pass
```

</details>

# Related Links

- Issue: https://github.com/somadevfat/gold-bunseki-web/issues/31
