### PR TITLE
[Analytics] MT5から定時POSTするノートPC同期スクリプトを実装する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,28 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-06 - Issue #75 MT5定時POSTスケジューラ実装
+
+- **達成したタスク**:
+  - Issue #75 `[Analytics] MT5から定時POSTするノートPC同期スクリプトを実装する` に対応。
+  - `feature/issue-75-scheduled-sync` ブランチを `develop` から作成。
+  - `apps/analytics/api/scheduled_sync.py` を追加し、`SCHEDULED_SYNC_TIMES` で指定した時刻に `gold_calendar_cache.json` のSHA-256ハッシュを確認する常駐スケジューラを実装。
+  - 前回POST済みハッシュと同一の場合はスキップし、差分がある場合のみ既存 `run_analysis_and_push()` を呼び出して Hono の `/api/v1/sync/data` へPOSTする構成にした。
+  - `HONO_SYNC_URL`, `API_TOKEN`, `SCHEDULED_SYNC_*`, `CALENDAR_CACHE_PATH` の設定を `.env.example`, `apps/analytics/README.md`, `docs/SYNC_AND_SEED.md` に追記。
+  - `apps/analytics/api/test_scheduled_sync.py` を追加し、時刻パース、指定時刻判定、差分ありPOST、差分なしスキップ、同一スロット二重実行防止を検証。
+
+- **検証結果**:
+  - `python3 -m unittest test_scheduled_sync`: 5 pass / 0 fail
+  - `python3 -m py_compile apps/analytics/api/scheduled_sync.py apps/analytics/api/server.py apps/analytics/api/test_scheduled_sync.py`: pass
+  - `.venv/bin/ruff check apps/analytics/api/server.py apps/analytics/api/scheduled_sync.py apps/analytics/api/test_scheduled_sync.py`: pass
+  - `bun run lint:all`: pass
+  - `bun run test:all`: frontend 53 pass / backend 100 pass
+
+- **次回への申し送り事項**:
+  - #76 で Windows タスクスケジューラ/自動起動/ログ保存/スリープ抑止の運用設定を詰める。
+  - #77 で Backend 側の同期状態更新・確認手順を強化する。
+  - 実機ノートPCでは MT5 と `GoldCalendarPush.mq5` を常時起動し、`SCHEDULED_SYNC_TIMES` と本番 `HONO_SYNC_URL` / `API_TOKEN` を設定して疎通確認する。
+
 ### 2026-05-06 - PR #92 掲示板投稿作成APIテストのCI失敗修正確認
 
 - **達成したタスク**:

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,18 @@ GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 # 本番のバックエンドAPIのURL (VPSのIPなど) に向けます
 # ex) HONO_SYNC_URL=http://35.x.x.x:3000/api/v1/sync/data
 HONO_SYNC_URL=http://localhost:3000/api/v1/sync/data
+
+# MT5カレンダーJSONの差分を指定時刻に確認し、変化があればHonoへPushします。
+# 空欄ならスケジューラは無効です。複数時刻はカンマ区切りで指定します。
+# ex) SCHEDULED_SYNC_TIMES=08:00,21:30
+SCHEDULED_SYNC_TIMES=
+SCHEDULED_SYNC_TIMEZONE=Asia/Tokyo
+SCHEDULED_SYNC_POLL_SECONDS=30
+SCHEDULED_SYNC_DUE_WINDOW_SECONDS=90
+SCHEDULED_SYNC_SYMBOL=GOLD
+SCHEDULED_SYNC_FETCH_COUNT=500
+
+# 通常は自動検出されるため空欄でOKです。
+# ex) CALENDAR_CACHE_PATH=C:\Users\you\AppData\Roaming\MetaQuotes\Terminal\Common\Files\gold_calendar_cache.json
+CALENDAR_CACHE_PATH=
+SCHEDULED_SYNC_STATE_PATH=

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -66,3 +66,24 @@ python api/server.py
 ```bash
 curl -X POST http://localhost:8000/api/sync
 ```
+
+### 3. 指定時刻のJSON差分同期
+`SCHEDULED_SYNC_TIMES` を設定して FastAPI サーバーを常時起動すると、指定時刻に
+`gold_calendar_cache.json` の内容ハッシュを確認し、前回Honoへ送信したJSONと差分がある場合だけ
+既存の同期処理を実行します。差分がない時刻はスキップされます。
+
+```powershell
+$env:API_TOKEN="backendと同じtoken"
+$env:HONO_SYNC_URL="https://api.example.com/api/v1/sync/data"
+$env:SCHEDULED_SYNC_TIMES="08:00,21:30"
+$env:SCHEDULED_SYNC_TIMEZONE="Asia/Tokyo"
+python api/server.py
+```
+
+任意設定:
+- `CALENDAR_CACHE_PATH`: MT5の共通フォルダ以外にJSONを置く場合のパス
+- `SCHEDULED_SYNC_STATE_PATH`: 前回POST済みハッシュを保存するstateファイル
+- `SCHEDULED_SYNC_POLL_SECONDS`: 指定時刻を確認する間隔（デフォルト30秒）
+- `SCHEDULED_SYNC_DUE_WINDOW_SECONDS`: 指定時刻から何秒以内を実行対象にするか（デフォルト90秒）
+- `SCHEDULED_SYNC_SYMBOL`: MT5から取得する銘柄（デフォルト`GOLD`）
+- `SCHEDULED_SYNC_FETCH_COUNT`: 取得する直近1分足の本数（デフォルト`500`）

--- a/apps/analytics/api/scheduled_sync.py
+++ b/apps/analytics/api/scheduled_sync.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from datetime import time as dt_time
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -18,6 +19,11 @@ DEFAULT_DUE_WINDOW_SECONDS = 90
 
 @dataclass(frozen=True)
 class ScheduledSyncConfig:
+    """
+    ScheduledSyncConfig は定時JSON差分同期の実行設定です。
+    @responsibility 環境変数由来の同期時刻・監視ファイル・状態保存先を型付きで保持する。
+    """
+
     scheduled_times: tuple[dt_time, ...]
     calendar_path: Path
     state_path: Path
@@ -27,6 +33,11 @@ class ScheduledSyncConfig:
 
     @classmethod
     def from_env(cls) -> "ScheduledSyncConfig | None":
+        """
+        環境変数からスケジューラ設定を生成します。
+        @responsibility SCHEDULED_SYNC_TIMES の有無で有効/無効を判断し、
+        指定時は実行設定へ変換する。
+        """
         times = parse_scheduled_times(os.environ.get("SCHEDULED_SYNC_TIMES", ""))
         if not times:
             return None
@@ -57,6 +68,12 @@ class ScheduledSyncConfig:
 
 @dataclass(frozen=True)
 class ScheduledSyncResult:
+    """
+    ScheduledSyncResult は1回の定時差分判定結果です。
+    @responsibility 呼び出し元が同期実行/スキップ理由を判別できる
+    結果を表現する。
+    """
+
     status: str
     message: str
     slot_key: str | None = None
@@ -64,6 +81,12 @@ class ScheduledSyncResult:
 
 
 class JsonDiffSyncScheduler:
+    """
+    JsonDiffSyncScheduler はMT5カレンダーJSONの定時差分同期を管理します。
+    @responsibility 指定時刻にJSONの内容ハッシュを確認し、
+    差分がある場合だけ同期callbackを起動する。
+    """
+
     def __init__(
         self,
         config: ScheduledSyncConfig,
@@ -79,6 +102,10 @@ class JsonDiffSyncScheduler:
         self._thread: threading.Thread | None = None
 
     def start(self) -> None:
+        """
+        バックグラウンドスレッドでスケジューラを開始します。
+        @responsibility FastAPI起動中に重複スレッドを作らず定期判定ループを開始する。
+        """
         if self._thread and self._thread.is_alive():
             return
 
@@ -90,21 +117,31 @@ class JsonDiffSyncScheduler:
         self._thread.start()
 
     def stop(self) -> None:
+        """
+        バックグラウンドスレッドの停止を要求します。
+        @responsibility FastAPI終了時にスケジューラループを止め、
+        短時間だけjoinして終了を待つ。
+        """
         self._stop_event.set()
         if self._thread:
             self._thread.join(timeout=5)
 
     def evaluate_once(self, now: datetime | None = None) -> ScheduledSyncResult:
+        """
+        現在時刻で1回だけ差分同期判定を実行します。
+        @responsibility 指定時刻・前回状態・JSONハッシュを見て
+        同期callback実行可否を決める。
+        """
         current = now or self.now_provider()
-        due_time = find_due_time(
+        due_at = find_due_time(
             current,
             self.config.scheduled_times,
             self.config.due_window_seconds,
         )
-        if due_time is None:
+        if due_at is None:
             return ScheduledSyncResult("idle", "No scheduled sync slot is due.")
 
-        slot_key = build_slot_key(current, due_time)
+        slot_key = build_slot_key(due_at.date(), due_at.time())
         state = read_state(self.config.state_path)
         if state.get("last_slot_key") == slot_key:
             return ScheduledSyncResult(
@@ -156,6 +193,10 @@ class JsonDiffSyncScheduler:
         )
 
     def _run_loop(self) -> None:
+        """
+        停止要求まで定期的に差分判定を実行します。
+        @responsibility poll間隔でevaluate_onceを呼び、同期結果や例外をログへ出す。
+        """
         print(
             "[ScheduledSync] Started with slots: "
             + ", ".join(t.strftime("%H:%M") for t in self.config.scheduled_times)
@@ -171,10 +212,20 @@ class JsonDiffSyncScheduler:
             self._stop_event.wait(self.config.poll_seconds)
 
     def _default_now(self) -> datetime:
+        """
+        設定されたタイムゾーンの現在時刻を返します。
+        @responsibility スケジューラ判定用の時計をtimezone-aware datetimeとして
+        供給する。
+        """
         return datetime.now(ZoneInfo(self.config.timezone_name))
 
 
 def parse_scheduled_times(value: str) -> tuple[dt_time, ...]:
+    """
+    カンマ区切りの時刻設定をtimeタプルへ変換します。
+    @responsibility HH:MM または HH:MM:SS の設定値を検証し、
+    昇順に並べた実行時刻へ変換する。
+    """
     tokens = [token.strip() for token in value.split(",") if token.strip()]
     parsed: list[dt_time] = []
     for token in tokens:
@@ -190,6 +241,11 @@ def parse_scheduled_times(value: str) -> tuple[dt_time, ...]:
 
 
 def resolve_calendar_cache_path(value: str | None = None) -> Path:
+    """
+    MT5カレンダーJSONのパスを解決します。
+    @responsibility 明示パス、MT5共通フォルダ、ローカルfallbackの順に
+    監視対象を決める。
+    """
     if value:
         return Path(value)
 
@@ -211,24 +267,42 @@ def find_due_time(
     now: datetime,
     scheduled_times: tuple[dt_time, ...],
     due_window_seconds: int,
-) -> dt_time | None:
+) -> datetime | None:
+    """
+    実行ウィンドウ内のスケジュール日時を探します。
+    @responsibility 深夜またぎも考慮し、今日または前日のスロットが実行対象か判定する。
+    """
+    target_dates = (now.date(), now.date() - timedelta(days=1))
     for scheduled_time in scheduled_times:
-        scheduled_at = datetime.combine(
-            now.date(),
-            scheduled_time,
-            tzinfo=now.tzinfo,
-        )
-        if scheduled_at <= now < scheduled_at + timedelta(seconds=due_window_seconds):
-            return scheduled_time
+        for target_date in target_dates:
+            scheduled_at = datetime.combine(
+                target_date,
+                scheduled_time,
+                tzinfo=now.tzinfo,
+            )
+            if (
+                scheduled_at
+                <= now
+                < scheduled_at + timedelta(seconds=due_window_seconds)
+            ):
+                return scheduled_at
 
     return None
 
 
-def build_slot_key(now: datetime, scheduled_time: dt_time) -> str:
-    return f"{now.date().isoformat()}T{scheduled_time.strftime('%H:%M:%S')}"
+def build_slot_key(slot_date: date, scheduled_time: dt_time) -> str:
+    """
+    状態ファイル用のスロットキーを生成します。
+    @responsibility 同じ日付・時刻のスケジュールを一意に識別する文字列を作る。
+    """
+    return f"{slot_date.isoformat()}T{scheduled_time.strftime('%H:%M:%S')}"
 
 
 def hash_file(path: Path) -> str:
+    """
+    ファイルのSHA-256ハッシュを計算します。
+    @responsibility 大きなJSONでもメモリに全読み込みせず内容差分判定用digestを返す。
+    """
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
@@ -237,6 +311,11 @@ def hash_file(path: Path) -> str:
 
 
 def read_state(path: Path) -> dict:
+    """
+    前回同期状態を読み込みます。
+    @responsibility stateファイルが未作成なら空状態として扱い、
+    存在する場合はJSONを復元する。
+    """
     if not path.exists():
         return {}
 
@@ -245,7 +324,20 @@ def read_state(path: Path) -> dict:
 
 
 def write_state(path: Path, state: dict) -> None:
+    """
+    前回同期状態をアトミックに保存します。
+    @responsibility 一時ファイルへ完全なJSONを書き出してから置換し、
+    書き込み途中のstate破損を避ける。
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
         json.dump(state, handle, ensure_ascii=True, indent=2, sort_keys=True)
         handle.write("\n")
+        temp_path = Path(handle.name)
+
+    temp_path.replace(path)

--- a/apps/analytics/api/scheduled_sync.py
+++ b/apps/analytics/api/scheduled_sync.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from datetime import time as dt_time
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+DEFAULT_TIMEZONE = "Asia/Tokyo"
+DEFAULT_POLL_SECONDS = 30
+DEFAULT_DUE_WINDOW_SECONDS = 90
+
+
+@dataclass(frozen=True)
+class ScheduledSyncConfig:
+    scheduled_times: tuple[dt_time, ...]
+    calendar_path: Path
+    state_path: Path
+    timezone_name: str = DEFAULT_TIMEZONE
+    poll_seconds: int = DEFAULT_POLL_SECONDS
+    due_window_seconds: int = DEFAULT_DUE_WINDOW_SECONDS
+
+    @classmethod
+    def from_env(cls) -> "ScheduledSyncConfig | None":
+        times = parse_scheduled_times(os.environ.get("SCHEDULED_SYNC_TIMES", ""))
+        if not times:
+            return None
+
+        return cls(
+            scheduled_times=times,
+            calendar_path=resolve_calendar_cache_path(
+                os.environ.get("CALENDAR_CACHE_PATH")
+            ),
+            state_path=Path(
+                os.environ.get(
+                    "SCHEDULED_SYNC_STATE_PATH",
+                    str(Path(__file__).resolve().parent.parent / ".sync_state.json"),
+                )
+            ),
+            timezone_name=os.environ.get("SCHEDULED_SYNC_TIMEZONE", DEFAULT_TIMEZONE),
+            poll_seconds=int(
+                os.environ.get("SCHEDULED_SYNC_POLL_SECONDS", DEFAULT_POLL_SECONDS)
+            ),
+            due_window_seconds=int(
+                os.environ.get(
+                    "SCHEDULED_SYNC_DUE_WINDOW_SECONDS",
+                    DEFAULT_DUE_WINDOW_SECONDS,
+                )
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ScheduledSyncResult:
+    status: str
+    message: str
+    slot_key: str | None = None
+    calendar_hash: str | None = None
+
+
+class JsonDiffSyncScheduler:
+    def __init__(
+        self,
+        config: ScheduledSyncConfig,
+        sync_callback,
+        now_provider=None,
+        sleep_func=time.sleep,
+    ):
+        self.config = config
+        self.sync_callback = sync_callback
+        self.now_provider = now_provider or self._default_now
+        self.sleep_func = sleep_func
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="scheduled-json-sync",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def evaluate_once(self, now: datetime | None = None) -> ScheduledSyncResult:
+        current = now or self.now_provider()
+        due_time = find_due_time(
+            current,
+            self.config.scheduled_times,
+            self.config.due_window_seconds,
+        )
+        if due_time is None:
+            return ScheduledSyncResult("idle", "No scheduled sync slot is due.")
+
+        slot_key = build_slot_key(current, due_time)
+        state = read_state(self.config.state_path)
+        if state.get("last_slot_key") == slot_key:
+            return ScheduledSyncResult(
+                "already_processed",
+                "This scheduled slot was already processed.",
+                slot_key=slot_key,
+            )
+
+        if not self.config.calendar_path.exists():
+            return ScheduledSyncResult(
+                "missing_calendar",
+                f"Calendar JSON was not found: {self.config.calendar_path}",
+                slot_key=slot_key,
+            )
+
+        current_hash = hash_file(self.config.calendar_path)
+        if state.get("last_calendar_hash") == current_hash:
+            write_state(
+                self.config.state_path,
+                {
+                    **state,
+                    "last_slot_key": slot_key,
+                    "last_checked_at": current.isoformat(),
+                    "last_status": "unchanged",
+                },
+            )
+            return ScheduledSyncResult(
+                "unchanged",
+                "Calendar JSON did not change since the last successful sync.",
+                slot_key=slot_key,
+                calendar_hash=current_hash,
+            )
+
+        self.sync_callback()
+        write_state(
+            self.config.state_path,
+            {
+                "last_calendar_hash": current_hash,
+                "last_slot_key": slot_key,
+                "last_synced_at": current.isoformat(),
+                "last_status": "synced",
+            },
+        )
+        return ScheduledSyncResult(
+            "synced",
+            "Calendar JSON changed; sync callback was triggered.",
+            slot_key=slot_key,
+            calendar_hash=current_hash,
+        )
+
+    def _run_loop(self) -> None:
+        print(
+            "[ScheduledSync] Started with slots: "
+            + ", ".join(t.strftime("%H:%M") for t in self.config.scheduled_times)
+        )
+        while not self._stop_event.is_set():
+            try:
+                result = self.evaluate_once()
+                if result.status != "idle":
+                    print(f"[ScheduledSync] {result.status}: {result.message}")
+            except Exception as exc:
+                print(f"[ScheduledSync] Error: {exc}")
+
+            self._stop_event.wait(self.config.poll_seconds)
+
+    def _default_now(self) -> datetime:
+        return datetime.now(ZoneInfo(self.config.timezone_name))
+
+
+def parse_scheduled_times(value: str) -> tuple[dt_time, ...]:
+    tokens = [token.strip() for token in value.split(",") if token.strip()]
+    parsed: list[dt_time] = []
+    for token in tokens:
+        parts = token.split(":")
+        if len(parts) not in (2, 3):
+            raise ValueError(f"Invalid scheduled time: {token}")
+
+        hour, minute = int(parts[0]), int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+        parsed.append(dt_time(hour=hour, minute=minute, second=second))
+
+    return tuple(sorted(parsed))
+
+
+def resolve_calendar_cache_path(value: str | None = None) -> Path:
+    if value:
+        return Path(value)
+
+    appdata = os.getenv("APPDATA")
+    if appdata:
+        return (
+            Path(appdata)
+            / "MetaQuotes"
+            / "Terminal"
+            / "Common"
+            / "Files"
+            / "gold_calendar_cache.json"
+        )
+
+    return Path("gold_calendar_cache.json")
+
+
+def find_due_time(
+    now: datetime,
+    scheduled_times: tuple[dt_time, ...],
+    due_window_seconds: int,
+) -> dt_time | None:
+    for scheduled_time in scheduled_times:
+        scheduled_at = datetime.combine(
+            now.date(),
+            scheduled_time,
+            tzinfo=now.tzinfo,
+        )
+        if scheduled_at <= now < scheduled_at + timedelta(seconds=due_window_seconds):
+            return scheduled_time
+
+    return None
+
+
+def build_slot_key(now: datetime, scheduled_time: dt_time) -> str:
+    return f"{now.date().isoformat()}T{scheduled_time.strftime('%H:%M:%S')}"
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, ensure_ascii=True, indent=2, sort_keys=True)
+        handle.write("\n")

--- a/apps/analytics/api/server.py
+++ b/apps/analytics/api/server.py
@@ -30,82 +30,115 @@ HONO_SYNC_URL = os.environ.get(
 SCHEDULED_SYNC_SYMBOL = os.environ.get("SCHEDULED_SYNC_SYMBOL", "GOLD")
 SCHEDULED_SYNC_FETCH_COUNT = int(os.environ.get("SCHEDULED_SYNC_FETCH_COUNT", "500"))
 scheduled_sync_scheduler: JsonDiffSyncScheduler | None = None
+_mt5_lock = threading.Lock()
+
 
 def run_analysis_and_push(symbol: str = "GOLD", fetch_count: int = 500):
-    """MT5から直近の価格を取得し、カレンダーと合わせて分析、HonoへPOSTする"""
+    """
+    MT5から直近の価格を取得し、カレンダーと合わせて分析、HonoへPOSTします。
+    @responsibility MT5接続を排他制御しながら、
+    価格取得・分析・認証付きPush同期を一連で実行する。
+    """
     print("=====================================================")
     print(f"[Sync] {symbol} の差分同期を開始します...")
 
-    if not mt5.initialize():
-        print("[Sync] ❌ MT5の初期化に失敗しました。MT5が起動中か確認してください。")
-        return
-
-    try:
-        # 1. MT5から直近の価格データ取得
-        rates = mt5.copy_rates_from_pos(symbol, mt5.TIMEFRAME_M1, 0, fetch_count)
-        if rates is None or len(rates) == 0:
-            print(f"[Sync] ❌ {symbol} の価格データが取得できませんでした。")
-            return
-
-        price_df = pd.DataFrame(rates)
-        price_df['Datetime_JST'] = pd.to_datetime(price_df['time'], unit='s')
-        price_df = price_df.rename(
-            columns={"open": "OPEN", "high": "HIGH", "low": "LOW", "close": "CLOSE"}
-        )
-        price_df.set_index('Datetime_JST', inplace=True)
-
-        # 2. カレンダーデータの読み込み
-        analyzer = MarketAnalyzer(xm_to_jst_offset_hours=7)
-        calendar_df = analyzer.load_calendar_data('auto')
-
-        # 3. MarketAnalyzerで分析実行
-        result_df = analyzer.analyze_sessions(price_df, calendar_df)
-
-        # 4. JSONペイロード構築
-        payload = analyzer.prepare_api_payload(result_df, calendar_df, price_df)
-
-        # 5. Hono DBへPOST送信
-        print(f"[Sync] Honoバックエンド ({HONO_SYNC_URL}) へ POST 送信中...")
-        headers = {"Content-Type": "application/json"}
-
-        api_token = os.environ.get("API_TOKEN")
-        if not api_token:
+    with _mt5_lock:
+        if not mt5.initialize():
             print(
-                "[Sync] 💣 致命的エラー: API_TOKEN 環境変数が設定されていません。"
-                "終了します。"
+                "[Sync] ❌ MT5の初期化に失敗しました。"
+                "MT5が起動中か確認してください。"
             )
             return
 
-        headers["Authorization"] = f"Bearer {api_token}"
+        try:
+            # 1. MT5から直近の価格データ取得
+            rates = mt5.copy_rates_from_pos(symbol, mt5.TIMEFRAME_M1, 0, fetch_count)
+            if rates is None or len(rates) == 0:
+                print(f"[Sync] ❌ {symbol} の価格データが取得できませんでした。")
+                return
 
-        res = requests.post(HONO_SYNC_URL, json=payload, headers=headers, timeout=30)
+            price_df = pd.DataFrame(rates)
+            price_df['Datetime_JST'] = pd.to_datetime(price_df['time'], unit='s')
+            price_df = price_df.rename(
+                columns={
+                    "open": "OPEN",
+                    "high": "HIGH",
+                    "low": "LOW",
+                    "close": "CLOSE",
+                }
+            )
+            price_df.set_index('Datetime_JST', inplace=True)
 
-        if res.status_code == 200:
-            print("[Sync] ✅ HonoへのPush同期が完了しました！ (HTTP 200)")
-        else:
-            print(f"[Sync] ❌ HonoへのPush失敗: HTTP {res.status_code}")
-            print(res.text)
+            # 2. カレンダーデータの読み込み
+            analyzer = MarketAnalyzer(xm_to_jst_offset_hours=7)
+            calendar_df = analyzer.load_calendar_data('auto')
 
-    except Exception as e:
-        print(f"[Sync] エラー発生: {e}")
-    finally:
-        mt5.shutdown()
-        print("=====================================================")
+            # 3. MarketAnalyzerで分析実行
+            result_df = analyzer.analyze_sessions(price_df, calendar_df)
+
+            # 4. JSONペイロード構築
+            payload = analyzer.prepare_api_payload(result_df, calendar_df, price_df)
+
+            # 5. Hono DBへPOST送信
+            print(f"[Sync] Honoバックエンド ({HONO_SYNC_URL}) へ POST 送信中...")
+            headers = {"Content-Type": "application/json"}
+
+            api_token = os.environ.get("API_TOKEN")
+            if not api_token:
+                print(
+                    "[Sync] 💣 致命的エラー: API_TOKEN 環境変数が設定されていません。"
+                    "終了します。"
+                )
+                return
+
+            headers["Authorization"] = f"Bearer {api_token}"
+
+            res = requests.post(
+                HONO_SYNC_URL,
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+
+            if res.status_code == 200:
+                print("[Sync] ✅ HonoへのPush同期が完了しました！ (HTTP 200)")
+            else:
+                print(f"[Sync] ❌ HonoへのPush失敗: HTTP {res.status_code}")
+                print(res.text)
+
+        except Exception as e:
+            print(f"[Sync] エラー発生: {e}")
+        finally:
+            mt5.shutdown()
+            print("=====================================================")
 
 @app.post("/api/sync")
 def trigger_sync():
-    """Honoや外部スケジューラーから手動/定期で同期処理を呼び出すエンドポイント"""
+    """
+    Honoや外部スケジューラーから手動/定期で同期処理を呼び出すエンドポイントです。
+    @responsibility HTTPトリガーをバックグラウンド同期実行へ変換し、
+    呼び出し元へ即時応答する。
+    """
     threading.Thread(target=run_analysis_and_push).start()
     return {"status": "Processing in background"}
 
 @app.get("/health")
 def health_check():
+    """
+    Analytics APIのヘルスチェックを返します。
+    @responsibility 常駐FastAPIサーバーが起動していることを確認できる
+    最小応答を提供する。
+    """
     return {"status": "ok"}
 
 
 @app.on_event("startup")
 def start_scheduled_sync():
-    """環境変数が設定されている場合のみ、JSON差分同期スケジューラを開始する"""
+    """
+    環境変数が設定されている場合のみ、JSON差分同期スケジューラを開始します。
+    @responsibility FastAPI起動時に定時同期設定を読み、
+    必要な場合だけ常駐スケジューラを起動する。
+    """
     global scheduled_sync_scheduler
 
     config = ScheduledSyncConfig.from_env()
@@ -125,7 +158,10 @@ def start_scheduled_sync():
 
 @app.on_event("shutdown")
 def stop_scheduled_sync():
-    """FastAPI終了時にスケジューラを停止する"""
+    """
+    FastAPI終了時にスケジューラを停止します。
+    @responsibility アプリ終了時に定時同期スレッドへ停止要求を出し、後始末を行う。
+    """
     if scheduled_sync_scheduler is not None:
         scheduled_sync_scheduler.stop()
 

--- a/apps/analytics/api/server.py
+++ b/apps/analytics/api/server.py
@@ -1,18 +1,19 @@
 import os
 import sys
 import threading
-import time
-import requests
 from pathlib import Path
-from fastapi import FastAPI, HTTPException
+
+import pandas as pd
+import requests
 import uvicorn
+from fastapi import FastAPI
 
 # 親ディレクトリ(apps/analytics)のcoreモジュールを参照できるようにする
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from core.market_analyzer import MarketAnalyzer
-
 import MetaTrader5 as mt5
-import pandas as pd
+from scheduled_sync import JsonDiffSyncScheduler, ScheduledSyncConfig
+
+from core.market_analyzer import MarketAnalyzer
 
 app = FastAPI(
     title="Gold Volatility API",
@@ -22,13 +23,19 @@ app = FastAPI(
 # =============================================================================
 # 設定
 # =============================================================================
-HONO_SYNC_URL = "http://localhost:3000/api/v1/sync/data"
+HONO_SYNC_URL = os.environ.get(
+    "HONO_SYNC_URL",
+    "http://localhost:3000/api/v1/sync/data",
+)
+SCHEDULED_SYNC_SYMBOL = os.environ.get("SCHEDULED_SYNC_SYMBOL", "GOLD")
+SCHEDULED_SYNC_FETCH_COUNT = int(os.environ.get("SCHEDULED_SYNC_FETCH_COUNT", "500"))
+scheduled_sync_scheduler: JsonDiffSyncScheduler | None = None
 
 def run_analysis_and_push(symbol: str = "GOLD", fetch_count: int = 500):
     """MT5から直近の価格を取得し、カレンダーと合わせて分析、HonoへPOSTする"""
     print("=====================================================")
     print(f"[Sync] {symbol} の差分同期を開始します...")
-    
+
     if not mt5.initialize():
         print("[Sync] ❌ MT5の初期化に失敗しました。MT5が起動中か確認してください。")
         return
@@ -39,12 +46,14 @@ def run_analysis_and_push(symbol: str = "GOLD", fetch_count: int = 500):
         if rates is None or len(rates) == 0:
             print(f"[Sync] ❌ {symbol} の価格データが取得できませんでした。")
             return
-            
+
         price_df = pd.DataFrame(rates)
         price_df['Datetime_JST'] = pd.to_datetime(price_df['time'], unit='s')
-        price_df = price_df.rename(columns={'open': 'OPEN', 'high': 'HIGH', 'low': 'LOW', 'close': 'CLOSE'})
+        price_df = price_df.rename(
+            columns={"open": "OPEN", "high": "HIGH", "low": "LOW", "close": "CLOSE"}
+        )
         price_df.set_index('Datetime_JST', inplace=True)
-        
+
         # 2. カレンダーデータの読み込み
         analyzer = MarketAnalyzer(xm_to_jst_offset_hours=7)
         calendar_df = analyzer.load_calendar_data('auto')
@@ -54,22 +63,25 @@ def run_analysis_and_push(symbol: str = "GOLD", fetch_count: int = 500):
 
         # 4. JSONペイロード構築
         payload = analyzer.prepare_api_payload(result_df, calendar_df, price_df)
-        
+
         # 5. Hono DBへPOST送信
         print(f"[Sync] Honoバックエンド ({HONO_SYNC_URL}) へ POST 送信中...")
         headers = {"Content-Type": "application/json"}
-        
+
         api_token = os.environ.get("API_TOKEN")
         if not api_token:
-            print("[Sync] 💣 致命的エラー: API_TOKEN 環境変数が設定されていません。終了します。")
+            print(
+                "[Sync] 💣 致命的エラー: API_TOKEN 環境変数が設定されていません。"
+                "終了します。"
+            )
             return
-            
+
         headers["Authorization"] = f"Bearer {api_token}"
-        
+
         res = requests.post(HONO_SYNC_URL, json=payload, headers=headers, timeout=30)
-        
+
         if res.status_code == 200:
-            print(f"[Sync] ✅ HonoへのPush同期が完了しました！ (HTTP 200)")
+            print("[Sync] ✅ HonoへのPush同期が完了しました！ (HTTP 200)")
         else:
             print(f"[Sync] ❌ HonoへのPush失敗: HTTP {res.status_code}")
             print(res.text)
@@ -89,6 +101,33 @@ def trigger_sync():
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+@app.on_event("startup")
+def start_scheduled_sync():
+    """環境変数が設定されている場合のみ、JSON差分同期スケジューラを開始する"""
+    global scheduled_sync_scheduler
+
+    config = ScheduledSyncConfig.from_env()
+    if config is None:
+        print("[ScheduledSync] Disabled. Set SCHEDULED_SYNC_TIMES to enable it.")
+        return
+
+    scheduled_sync_scheduler = JsonDiffSyncScheduler(
+        config=config,
+        sync_callback=lambda: run_analysis_and_push(
+            symbol=SCHEDULED_SYNC_SYMBOL,
+            fetch_count=SCHEDULED_SYNC_FETCH_COUNT,
+        ),
+    )
+    scheduled_sync_scheduler.start()
+
+
+@app.on_event("shutdown")
+def stop_scheduled_sync():
+    """FastAPI終了時にスケジューラを停止する"""
+    if scheduled_sync_scheduler is not None:
+        scheduled_sync_scheduler.stop()
 
 if __name__ == "__main__":
     uvicorn.run("server:app", host="0.0.0.0", port=8000, reload=True)

--- a/apps/analytics/api/test_scheduled_sync.py
+++ b/apps/analytics/api/test_scheduled_sync.py
@@ -9,6 +9,7 @@ from scheduled_sync import (
     JsonDiffSyncScheduler,
     ScheduledSyncConfig,
     build_slot_key,
+    find_due_time,
     hash_file,
     parse_scheduled_times,
     read_state,
@@ -105,7 +106,7 @@ class JsonDiffSyncSchedulerTest(unittest.TestCase):
             state_path = tmp / "state.json"
             calendar_path.write_text('[{"name":"CPI"}]', encoding="utf-8")
             now = datetime(2026, 5, 6, 8, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
-            slot_key = build_slot_key(now, time(8, 0))
+            slot_key = build_slot_key(now.date(), time(8, 0))
             state_path.write_text(
                 json.dumps({"last_slot_key": slot_key}),
                 encoding="utf-8",
@@ -153,6 +154,19 @@ class JsonDiffSyncSchedulerTest(unittest.TestCase):
             # ## Assert ##
             self.assertEqual(result.status, "idle")
             self.assertEqual(calls, [])
+
+    def test_find_due_time_detects_previous_day_slot_across_midnight(self):
+        # ## Arrange ##
+        now = datetime(2026, 5, 7, 0, 0, 10, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+        # ## Act ##
+        due_at = find_due_time(now, (time(23, 59, 50),), 30)
+
+        # ## Assert ##
+        self.assertEqual(
+            due_at,
+            datetime(2026, 5, 6, 23, 59, 50, tzinfo=ZoneInfo("Asia/Tokyo")),
+        )
 
 
 if __name__ == "__main__":

--- a/apps/analytics/api/test_scheduled_sync.py
+++ b/apps/analytics/api/test_scheduled_sync.py
@@ -1,0 +1,159 @@
+import json
+import tempfile
+import unittest
+from datetime import datetime, time
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from scheduled_sync import (
+    JsonDiffSyncScheduler,
+    ScheduledSyncConfig,
+    build_slot_key,
+    hash_file,
+    parse_scheduled_times,
+    read_state,
+)
+
+
+class JsonDiffSyncSchedulerTest(unittest.TestCase):
+    def test_parse_scheduled_times_sorts_multiple_times(self):
+        # ## Arrange ##
+        value = "21:30, 08:00:15"
+
+        # ## Act ##
+        parsed = parse_scheduled_times(value)
+
+        # ## Assert ##
+        self.assertEqual(parsed, (time(8, 0, 15), time(21, 30)))
+
+    def test_evaluate_once_posts_when_due_calendar_changed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # ## Arrange ##
+            tmp = Path(tmpdir)
+            calendar_path = tmp / "gold_calendar_cache.json"
+            state_path = tmp / "state.json"
+            calendar_path.write_text('[{"name":"CPI"}]', encoding="utf-8")
+            calls = []
+            now = datetime(2026, 5, 6, 8, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
+            config = ScheduledSyncConfig(
+                scheduled_times=(time(8, 0),),
+                calendar_path=calendar_path,
+                state_path=state_path,
+            )
+            scheduler = JsonDiffSyncScheduler(
+                config, sync_callback=lambda: calls.append("sync")
+            )
+
+            # ## Act ##
+            result = scheduler.evaluate_once(now)
+
+            # ## Assert ##
+            self.assertEqual(result.status, "synced")
+            self.assertEqual(calls, ["sync"])
+            self.assertEqual(
+                read_state(state_path),
+                {
+                    "last_calendar_hash": hash_file(calendar_path),
+                    "last_slot_key": "2026-05-06T08:00:00",
+                    "last_status": "synced",
+                    "last_synced_at": now.isoformat(),
+                },
+            )
+
+    def test_evaluate_once_skips_when_due_calendar_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # ## Arrange ##
+            tmp = Path(tmpdir)
+            calendar_path = tmp / "gold_calendar_cache.json"
+            state_path = tmp / "state.json"
+            calendar_path.write_text('[{"name":"CPI"}]', encoding="utf-8")
+            now = datetime(2026, 5, 6, 8, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "last_calendar_hash": hash_file(calendar_path),
+                        "last_slot_key": "2026-05-05T08:00:00",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            calls = []
+            config = ScheduledSyncConfig(
+                scheduled_times=(time(8, 0),),
+                calendar_path=calendar_path,
+                state_path=state_path,
+            )
+            scheduler = JsonDiffSyncScheduler(
+                config, sync_callback=lambda: calls.append("sync")
+            )
+
+            # ## Act ##
+            result = scheduler.evaluate_once(now)
+
+            # ## Assert ##
+            self.assertEqual(result.status, "unchanged")
+            self.assertEqual(calls, [])
+            self.assertEqual(
+                read_state(state_path)["last_slot_key"], "2026-05-06T08:00:00"
+            )
+
+    def test_evaluate_once_skips_already_processed_slot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # ## Arrange ##
+            tmp = Path(tmpdir)
+            calendar_path = tmp / "gold_calendar_cache.json"
+            state_path = tmp / "state.json"
+            calendar_path.write_text('[{"name":"CPI"}]', encoding="utf-8")
+            now = datetime(2026, 5, 6, 8, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
+            slot_key = build_slot_key(now, time(8, 0))
+            state_path.write_text(
+                json.dumps({"last_slot_key": slot_key}),
+                encoding="utf-8",
+            )
+            calls = []
+            config = ScheduledSyncConfig(
+                scheduled_times=(time(8, 0),),
+                calendar_path=calendar_path,
+                state_path=state_path,
+            )
+            scheduler = JsonDiffSyncScheduler(
+                config, sync_callback=lambda: calls.append("sync")
+            )
+
+            # ## Act ##
+            result = scheduler.evaluate_once(now)
+
+            # ## Assert ##
+            self.assertEqual(result.status, "already_processed")
+            self.assertEqual(calls, [])
+
+    def test_evaluate_once_is_idle_outside_due_window(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # ## Arrange ##
+            tmp = Path(tmpdir)
+            calendar_path = tmp / "gold_calendar_cache.json"
+            state_path = tmp / "state.json"
+            calendar_path.write_text('[{"name":"CPI"}]', encoding="utf-8")
+            calls = []
+            config = ScheduledSyncConfig(
+                scheduled_times=(time(8, 0),),
+                calendar_path=calendar_path,
+                state_path=state_path,
+                due_window_seconds=90,
+            )
+            scheduler = JsonDiffSyncScheduler(
+                config, sync_callback=lambda: calls.append("sync")
+            )
+
+            # ## Act ##
+            result = scheduler.evaluate_once(
+                datetime(2026, 5, 6, 8, 2, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+            )
+
+            # ## Assert ##
+            self.assertEqual(result.status, "idle")
+            self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/SYNC_AND_SEED.md
+++ b/docs/SYNC_AND_SEED.md
@@ -107,3 +107,24 @@ curl -X POST http://localhost:8000/api/sync
 ```
 
 *(※ `apps/analytics/api/server.py` 内の `HONO_SYNC_URL` は、本番デプロイ時はVPSのドメイン/IPアドレスに書き換えてください)*
+
+### Step 2.4: 指定時刻のJSON差分同期 (任意)
+WindowsPC上で FastAPI サーバーを常時起動し、`SCHEDULED_SYNC_TIMES` を設定すると、指定時刻に
+MT5 EA が出力した `gold_calendar_cache.json` の内容ハッシュを確認します。
+前回Honoへ送信したJSONから変化がある場合だけ、既存の差分同期処理を実行して
+`/api/v1/sync/data` へPOSTします。
+
+```powershell
+$env:API_TOKEN="backendと同じtoken"
+$env:HONO_SYNC_URL="https://api.example.com/api/v1/sync/data"
+$env:SCHEDULED_SYNC_TIMES="08:00,21:30"
+$env:SCHEDULED_SYNC_TIMEZONE="Asia/Tokyo"
+python api/server.py
+```
+
+補足:
+- `SCHEDULED_SYNC_TIMES` が空の場合、スケジューラは無効です。
+- 複数時刻は `08:00,21:30` のようにカンマ区切りで指定します。
+- JSONの場所は通常 `%APPDATA%\MetaQuotes\Terminal\Common\Files\gold_calendar_cache.json` を自動検出します。
+- `CALENDAR_CACHE_PATH` を設定すると、任意のJSONファイルを監視対象にできます。
+- 前回POST済みハッシュは `SCHEDULED_SYNC_STATE_PATH`、未指定時は `apps/analytics/.sync_state.json` に保存されます。


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #75

# Todo

- [x] MT5カレンダーJSONの差分を指定時刻に確認するスケジューラを追加
- [x] JSONに差分がある場合のみ既存のHono Push同期を実行
- [x] `HONO_SYNC_URL` / `API_TOKEN` / `SCHEDULED_SYNC_*` / `CALENDAR_CACHE_PATH` を環境変数で切り替え可能にする
- [x] 同一スロットの二重実行と差分なし再送を防ぐstate管理を追加
- [x] 定時同期の運用手順をREADMEと同期ドキュメントへ追記
- [x] スケジューラのユニットテストを追加

# How to check (動作確認の手順)

```zsh
# Pythonスケジューラのユニットテスト
cd apps/analytics/api
python3 -m unittest test_scheduled_sync

# 変更Pythonファイルの構文確認
cd ../../..
python3 -m py_compile apps/analytics/api/scheduled_sync.py apps/analytics/api/server.py apps/analytics/api/test_scheduled_sync.py

# 全体品質ゲート
PATH=/home/somah/.bun/bin:$PATH bun run lint:all
PATH=/home/somah/.bun/bin:$PATH bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-06 22:43 (JST)
- ブランチ: feature/issue-75-scheduled-sync

```zsh
python3 -m unittest test_scheduled_sync
.....
----------------------------------------------------------------------
Ran 5 tests in 0.100s

OK

python3 -m py_compile apps/analytics/api/scheduled_sync.py apps/analytics/api/server.py apps/analytics/api/test_scheduled_sync.py
# pass

.venv/bin/ruff check apps/analytics/api/server.py apps/analytics/api/scheduled_sync.py apps/analytics/api/test_scheduled_sync.py
All checks passed!

PATH=/home/somah/.bun/bin:$PATH bun run lint:all
# frontend eslint: pass
# backend eslint: pass

PATH=/home/somah/.bun/bin:$PATH bun run test:all
# frontend: 53 pass / 0 fail
# backend: 100 pass / 0 fail
```

</details>

# Related Links

- docs/SYNC_AND_SEED.md
- apps/analytics/README.md
