### PR TITLE
feat: add privacy and API docs pages

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,25 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-08 - Issue #41/#43 フッター導線ページ追加
+
+- **達成したタスク**:
+  - ノートPC同期系以外で依存が軽い Issue #41 `Privacy & Securityページ` と Issue #43 `APIドキュメントページ導線` に対応。
+  - `feature/issues-41-43-footer-pages` ブランチを `develop` から作成。
+  - `/privacy` ページを追加し、収集情報、利用目的、Cookie/認証、MT5同期データ、セキュリティ、問い合わせ先を説明。
+  - `/api-docs` ページを追加し、Swagger UI / OpenAPI JSON へのリンクと Market / Sync / Community API の用途を説明。
+  - フッターの `API` リンクを `/api-docs` に修正し、`/privacy` と `/api-docs` を sitemap に追加。
+  - ページ表示、SEO metadata、フッターリンクのテストを追加。
+
+- **検証結果**:
+  - `cd apps/frontend && bun test src/app/privacy/page.test.tsx src/app/api-docs/page.test.tsx src/features/common/components/SiteFooter.test.tsx`: 5 pass / 0 fail
+  - `bun run lint:all`: pass
+  - `bun run test:all`: frontend 58 pass / backend 100 pass
+
+- **次回への申し送り事項**:
+  - #41/#43 はPRマージ後に完了コメント付きでクローズする。
+  - 次に同期以外で進めるなら、依存が満たされた #32 掲示板スレッド詳細/返信UI、または #37 リサーチメモ保存API が進めやすい。
+
 ### 2026-05-06 - Issue #75 MT5定時POSTスケジューラ実装
 
 - **達成したタスク**:

--- a/apps/frontend/src/app/api-docs/page.test.tsx
+++ b/apps/frontend/src/app/api-docs/page.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import ApiDocsPage, { metadata } from "./page";
+
+describe("ApiDocsPage", () => {
+  it("API仕様への導線と主要APIの用途を表示すること", () => {
+    render(<ApiDocsPage />);
+
+    expect(screen.getByRole("heading", { name: "API Documentation" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Swagger UI" }).getAttribute("href"))
+      .toBe("http://localhost:3000/swagger");
+    expect(screen.getByRole("link", { name: "OpenAPI JSON" }).getAttribute("href"))
+      .toBe("http://localhost:3000/doc");
+    expect(screen.getByText("Market API")).toBeDefined();
+    expect(screen.getByText("Sync API")).toBeDefined();
+    expect(screen.getByText("Community API")).toBeDefined();
+    expect(screen.getByText(/APIドキュメントが開けない場合/)).toBeDefined();
+  });
+
+  it("SEO metadata が設定されていること", () => {
+    expect(metadata.title).toBe("API Documentation");
+    expect(metadata.description).toContain("Swagger");
+    expect(metadata.alternates).toEqual({ canonical: "/api-docs" });
+  });
+});

--- a/apps/frontend/src/app/api-docs/page.tsx
+++ b/apps/frontend/src/app/api-docs/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+const apiGroups = [
+  {
+    title: "Market API",
+    description:
+      "最新価格、セッション別ボラティリティ、指標リプレイ、ZigZag計算のためのAPIです。",
+    paths: ["/api/v1/market/sessions", "/api/v1/market/replay", "/api/v1/market/indicators"],
+  },
+  {
+    title: "Sync API",
+    description:
+      "MT5/Python同期サーバーから送られる価格・指標・セッション分析データを受け取るAPIです。",
+    paths: ["/api/v1/sync/data", "/api/v1/sync/seed", "/api/v1/sync/status"],
+  },
+  {
+    title: "Community API",
+    description:
+      "XAUUSD分析・GOLD分析の掲示板投稿、投稿詳細、返信を扱うAPIです。",
+    paths: ["/api/v1/community/threads", "/api/v1/community/threads/{id}"],
+  },
+];
+
+export const metadata: Metadata = {
+  title: "API Documentation",
+  description:
+    "fanda-devのSwagger/OpenAPI仕様、主要API、同期API、掲示板APIへの導線をまとめたページです。",
+  alternates: {
+    canonical: "/api-docs",
+  },
+};
+
+/**
+ * ApiDocsPage はAPI仕様への導線と主要APIの概要を表示するページです。
+ * @responsibility Swagger/OpenAPIの場所、主要APIの用途、利用できない場合の確認先を案内する。
+ */
+export default function ApiDocsPage() {
+  return (
+    <section className="rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 sm:p-8 lg:p-10">
+      <div className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.26em] text-amber-700">
+          Developer Reference
+        </p>
+        <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">
+          API Documentation
+        </h1>
+        <p className="mt-5 text-base leading-8 text-slate-600">
+          fanda-devのバックエンドAPIはHono Zod OpenAPIで定義されています。
+          Swagger UIとOpenAPI JSONから、画面表示・同期・掲示板で使うAPI仕様を確認できます。
+        </p>
+      </div>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        <a
+          href={`${apiBaseUrl}/swagger`}
+          className="rounded-xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
+        >
+          Swagger UI
+        </a>
+        <a
+          href={`${apiBaseUrl}/doc`}
+          className="rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-900 transition-colors hover:border-slate-400"
+        >
+          OpenAPI JSON
+        </a>
+      </div>
+
+      <div className="mt-10 grid gap-4 lg:grid-cols-3">
+        {apiGroups.map((group) => (
+          <article
+            key={group.title}
+            className="rounded-2xl border border-slate-200 bg-[#fbfaf7] p-5"
+          >
+            <h2 className="text-base font-semibold text-slate-950">
+              {group.title}
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              {group.description}
+            </p>
+            <ul className="mt-4 space-y-2 text-xs font-medium text-slate-500">
+              {group.paths.map((path) => (
+                <li key={path} className="rounded-lg bg-white px-3 py-2">
+                  <code>{path}</code>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-8 rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm leading-7 text-amber-950">
+        APIドキュメントが開けない場合は、バックエンドが起動していること、
+        `NEXT_PUBLIC_API_URL` が本番APIまたはローカルAPIを指していることを確認してください。
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/app/privacy/page.test.tsx
+++ b/apps/frontend/src/app/privacy/page.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import PrivacyPage, { metadata } from "./page";
+
+describe("PrivacyPage", () => {
+  it("プライバシーとセキュリティ方針を表示すること", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByRole("heading", { name: "Privacy & Security" })).toBeDefined();
+    expect(screen.getByText("収集する情報")).toBeDefined();
+    expect(screen.getByText("Cookieと認証")).toBeDefined();
+    expect(screen.getByText("問い合わせ")).toBeDefined();
+  });
+
+  it("SEO metadata が設定されていること", () => {
+    expect(metadata.title).toBe("Privacy & Security");
+    expect(metadata.description).toContain("プライバシー");
+    expect(metadata.alternates).toEqual({ canonical: "/privacy" });
+  });
+});

--- a/apps/frontend/src/app/privacy/page.tsx
+++ b/apps/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy & Security",
+  description:
+    "fanda-devのプライバシー、Cookie、Google認証、データ同期、セキュリティ方針を説明します。",
+  alternates: {
+    canonical: "/privacy",
+  },
+};
+
+const policySections = [
+  {
+    title: "収集する情報",
+    body: "Googleログイン時のアカウント識別情報、掲示板投稿、リサーチメモ、サービス改善に必要なアクセス情報を扱います。",
+  },
+  {
+    title: "利用目的",
+    body: "認証、投稿やメモの保存、XAUUSD分析・GOLD分析の利用体験改善、不正利用の防止に利用します。",
+  },
+  {
+    title: "Cookieと認証",
+    body: "ログイン状態の維持とセッション保護のためにCookieを使用します。認証処理はbetter-authとGoogle OAuthを利用します。",
+  },
+  {
+    title: "市場データと同期",
+    body: "MT5から取得した価格データや経済指標データは分析表示のために保存され、個人を特定する目的では利用しません。",
+  },
+  {
+    title: "セキュリティ",
+    body: "APIは同期用Bearer token、CORS制御、セキュリティヘッダー、サーバーログにより保護と原因調査を行います。",
+  },
+  {
+    title: "問い合わせ",
+    body: "プライバシーやセキュリティに関する確認は、GitHubリポジトリのIssueまたは管理者連絡先から相談できます。",
+  },
+];
+
+/**
+ * PrivacyPage はプライバシーとセキュリティ方針を表示するページです。
+ * @responsibility 収集情報、利用目的、Cookie/認証、同期データ、問い合わせ先を利用者へ説明する。
+ */
+export default function PrivacyPage() {
+  return (
+    <section className="rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 sm:p-8 lg:p-10">
+      <div className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.26em] text-amber-700">
+          Trust Center
+        </p>
+        <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">
+          Privacy &amp; Security
+        </h1>
+        <p className="mt-5 text-base leading-8 text-slate-600">
+          fanda-devは、XAUUSD分析・GOLD分析のために必要な情報だけを扱い、
+          認証情報と投稿データを安全に管理することを重視します。
+        </p>
+      </div>
+
+      <div className="mt-10 grid gap-4 md:grid-cols-2">
+        {policySections.map((section) => (
+          <article
+            key={section.title}
+            className="rounded-2xl border border-slate-200 bg-[#fbfaf7] p-5"
+          >
+            <h2 className="text-base font-semibold text-slate-950">
+              {section.title}
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              {section.body}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -14,5 +14,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: `${siteUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
+    {
+      url: `${siteUrl}/api-docs`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
   ];
 }

--- a/apps/frontend/src/features/common/components/SiteFooter.test.tsx
+++ b/apps/frontend/src/features/common/components/SiteFooter.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { SiteFooter } from "./SiteFooter";
+
+describe("SiteFooter", () => {
+  it("Privacy, Status, API ドキュメントへの導線を表示すること", () => {
+    render(<SiteFooter />);
+
+    expect(
+      screen.getByRole("link", { name: "Privacy & Security" }).getAttribute("href"),
+    ).toBe("/privacy");
+    expect(screen.getByRole("link", { name: "Status" }).getAttribute("href")).toBe(
+      "/status",
+    );
+    expect(screen.getByRole("link", { name: "API" }).getAttribute("href")).toBe(
+      "/api-docs",
+    );
+  });
+});

--- a/apps/frontend/src/features/common/components/SiteFooter.tsx
+++ b/apps/frontend/src/features/common/components/SiteFooter.tsx
@@ -20,7 +20,7 @@ export function SiteFooter() {
         <Link href="/status" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
           Status
         </Link>
-        <Link href="/api" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
+        <Link href="/api-docs" className="border-b border-transparent pb-1 transition-colors hover:border-slate-900 hover:text-slate-900">
           API
         </Link>
       </div>


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #41
Closes #43

# Todo

- [x] `/privacy` ページを追加し、プライバシーとセキュリティ方針を説明
- [x] `/api-docs` ページを追加し、Swagger/OpenAPIと主要APIの用途を案内
- [x] フッターの `API` 導線を `/api-docs` へ修正
- [x] `/privacy` と `/api-docs` を sitemap に追加
- [x] ページ表示、SEO metadata、フッターリンクのテストを追加

# How to check (動作確認の手順)

```zsh
cd apps/frontend
bun test src/app/privacy/page.test.tsx src/app/api-docs/page.test.tsx src/features/common/components/SiteFooter.test.tsx

cd ../..
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-08 00:43 (JST)
- ブランチ: feature/issues-41-43-footer-pages

```zsh
cd apps/frontend && bun test src/app/privacy/page.test.tsx src/app/api-docs/page.test.tsx src/features/common/components/SiteFooter.test.tsx
# 5 pass / 0 fail

bun run lint:all
# frontend eslint: pass
# backend eslint: pass

bun run test:all
# frontend: 58 pass / 0 fail
# backend: 100 pass / 0 fail
```

</details>

# Related Links

- `/privacy`
- `/api-docs`
