### PR TITLE
[FE] Statusページを実装する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,30 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-08 - Issue #42 Statusページ実装 / PR #97
+
+- **達成したタスク**:
+  - GitHub Issue一覧を取得し、ノートPC同期サーバー運用系（#76/#78）を除外して依存関係を確認。
+  - 依存なしで進められる #42 `[FE] Statusページを実装する` を選定し、`develop` から `feature/issue-42-status-page` を作成。
+  - `/status` ページを追加し、`/api/v1/sync/status` の `syncHealth`, 最終Candle/Session/Event、保存済みCandle件数を表示。
+  - 同期ステータス取得用の `getSyncStatus` フロントAPIラッパーと `SyncStatusResponse` 型を追加。
+  - API取得失敗時の案内表示、StatusページのSEO metadata、`/status` の sitemap 追加を実装。
+  - Statusページ、同期ステータス取得、sitemap のテストを追加。
+  - 既存の `getCommunityThreads.test.ts` が `excerpt` を使っていて `CommunityThread.body` 型とずれていたため、型チェック通過のため `body` に修正。
+  - PR #97 `https://github.com/somadevfat/gold-bunseki-web/pull/97` を `develop` 向けに作成。
+
+- **検証結果**:
+  - `cd apps/frontend && bun test src/app/status/page.test.tsx src/features/sync/api/getSyncStatus.test.ts src/app/sitemap.test.ts`: 7 pass / 0 fail
+  - `cd apps/frontend && ./node_modules/.bin/tsc --noEmit`: pass
+  - `cd apps/frontend && bun run build`: pass（Wranglerのホーム配下ログ書き込みで `EROFS` warning は出たが終了コード0）
+  - `bun run lint:all`: pass
+  - `bun run test:all`: frontend 65 pass / backend 100 pass
+
+- **次回への申し送り事項**:
+  - PR #97 のCI確認とレビュー対応を行う。
+  - ノートPC同期運用そのものは今回スコープ外。同期状態の精度をさらに高める場合は #77 を先に進める。
+  - 同期以外の次候補は、依存なしの #37 リサーチメモ保存API、または #33 考察ブログ記事ソース方式のSpike。
+
 ### 2026-05-08 - Issue #41/#43 フッター導線ページ追加
 
 - **達成したタスク**:

--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,24 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-08 - PR #97 Geminiレビューコメント対応
+
+- **達成したタスク**:
+  - PR #97 の未解決レビューコメント6件を `gh-address-comments` ワークフローで確認。
+  - `apps/frontend/src/app/status/page.tsx` の `formatDateTime`, `getHealthView`, `buildStatusItems`, `StatusContent`, `StatusPage` に `@responsibility` 付きJSDocを追加・位置修正。
+  - `apps/frontend/src/app/status/page.test.tsx` に `syncHealth: "Stale"` の表示分岐テストを追加。
+  - 修正コミット `851a800 fix: address status page review comments` をPRブランチへpush。
+  - 各レビューコメントへ対応内容を返信し、6件すべてのレビューThreadを resolved に変更。
+
+- **検証結果**:
+  - `cd apps/frontend && bun test src/app/status/page.test.tsx`: 4 pass / 0 fail
+  - `cd apps/frontend && bun run lint`: pass
+  - `bun run lint:all`: pass
+  - `bun run test:all`: frontend 66 pass / backend 100 pass
+
+- **次回への申し送り事項**:
+  - PR #97 はレビューコメント対応済み。追加CI/レビュー結果を確認して問題なければマージ可能。
+
 ### 2026-05-08 - Issue #42 Statusページ実装 / PR #97
 
 - **達成したタスク**:

--- a/apps/frontend/src/app/sitemap.test.ts
+++ b/apps/frontend/src/app/sitemap.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import sitemap from "./sitemap";
+
+describe("sitemap", () => {
+  it("主要ページのURLを含むこと", () => {
+    const urls = sitemap().map((item) => item.url);
+
+    expect(urls).toContain("https://fanda-dev.com");
+    expect(urls).toContain("https://fanda-dev.com/privacy");
+    expect(urls).toContain("https://fanda-dev.com/api-docs");
+    expect(urls).toContain("https://fanda-dev.com/status");
+  });
+});

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -26,5 +26,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.4,
     },
+    {
+      url: `${siteUrl}/status`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.5,
+    },
   ];
 }

--- a/apps/frontend/src/app/status/page.test.tsx
+++ b/apps/frontend/src/app/status/page.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { StatusContent, metadata } from "./page";
+
+describe("StatusPage", () => {
+  it("同期ステータスと最終更新情報を表示すること", () => {
+    render(<StatusContent status={{
+      lastCandleAt: "2026-04-01T10:00:00Z",
+      lastSessionAt: "2026-04-01",
+      lastEventAt: "2026-04-01T10:00:00Z",
+      totalCandles: 10000,
+      syncHealth: "Healthy",
+    }} />);
+
+    expect(screen.getByRole("heading", { name: "Status" })).toBeDefined();
+    expect(screen.getByText("Healthy")).toBeDefined();
+    expect(screen.getByText("Latest Candle")).toBeDefined();
+    expect(screen.getByText("Latest Session")).toBeDefined();
+    expect(screen.getByText("Latest Event")).toBeDefined();
+    expect(screen.getByText("Stored Candles")).toBeDefined();
+    expect(screen.getByText("10,000")).toBeDefined();
+  });
+
+  it("同期ステータスの取得に失敗した場合、案内を表示すること", () => {
+    render(<StatusContent status={null} errorMessage="同期ステータスの取得に失敗しました" />);
+
+    expect(screen.getByText("Unknown")).toBeDefined();
+    expect(screen.getByText(/バックエンドAPIの起動状態を確認してください/)).toBeDefined();
+  });
+
+  it("SEO metadata が設定されていること", () => {
+    expect(metadata.title).toBe("Status");
+    expect(metadata.description).toContain("同期ステータス");
+    expect(metadata.alternates).toEqual({ canonical: "/status" });
+  });
+});

--- a/apps/frontend/src/app/status/page.test.tsx
+++ b/apps/frontend/src/app/status/page.test.tsx
@@ -21,6 +21,19 @@ describe("StatusPage", () => {
     expect(screen.getByText("10,000")).toBeDefined();
   });
 
+  it("同期ステータスが Stale の場合、遅延案内を表示すること", () => {
+    render(<StatusContent status={{
+      lastCandleAt: "2026-04-01T10:00:00Z",
+      lastSessionAt: "2026-04-01",
+      lastEventAt: "2026-04-01T10:00:00Z",
+      totalCandles: 10000,
+      syncHealth: "Stale",
+    }} />);
+
+    expect(screen.getByText("Stale")).toBeDefined();
+    expect(screen.getByText("同期データの更新が遅れている可能性があります。")).toBeDefined();
+  });
+
   it("同期ステータスの取得に失敗した場合、案内を表示すること", () => {
     render(<StatusContent status={null} errorMessage="同期ステータスの取得に失敗しました" />);
 

--- a/apps/frontend/src/app/status/page.tsx
+++ b/apps/frontend/src/app/status/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import { getSyncStatus } from "@/features/sync/api/getSyncStatus";
+import type { SyncStatusResponse } from "@/lib/api/client";
+
+export const metadata: Metadata = {
+  title: "Status",
+  description:
+    "fanda-devのバックエンドAPI、同期ステータス、最終更新時刻を確認できるステータスページです。",
+  alternates: {
+    canonical: "/status",
+  },
+};
+
+const formatDateTime = (value: string) => {
+  if (!value) {
+    return "未取得";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Tokyo",
+  }).format(date);
+};
+
+const getHealthView = (syncHealth: string) => {
+  const normalized = syncHealth.toLowerCase();
+
+  if (normalized === "healthy") {
+    return {
+      label: "Healthy",
+      description: "バックエンドは同期データを正常に参照できます。",
+      className: "border-emerald-200 bg-emerald-50 text-emerald-800",
+      dotClassName: "bg-emerald-500",
+    };
+  }
+
+  if (normalized === "stale") {
+    return {
+      label: "Stale",
+      description: "同期データの更新が遅れている可能性があります。",
+      className: "border-amber-200 bg-amber-50 text-amber-900",
+      dotClassName: "bg-amber-500",
+    };
+  }
+
+  return {
+    label: syncHealth || "Unknown",
+    description: "同期状態を確認できませんでした。",
+    className: "border-rose-200 bg-rose-50 text-rose-900",
+    dotClassName: "bg-rose-500",
+  };
+};
+
+const buildStatusItems = (status: SyncStatusResponse) => [
+  {
+    label: "Latest Candle",
+    value: formatDateTime(status.lastCandleAt),
+    description: "価格足データの最終同期時刻",
+  },
+  {
+    label: "Latest Session",
+    value: formatDateTime(status.lastSessionAt),
+    description: "セッション集計データの最終更新日",
+  },
+  {
+    label: "Latest Event",
+    value: formatDateTime(status.lastEventAt),
+    description: "経済指標データの最終同期時刻",
+  },
+  {
+    label: "Stored Candles",
+    value: status.totalCandles.toLocaleString("ja-JP"),
+    description: "バックエンドで確認できる価格足件数",
+  },
+];
+
+/**
+ * StatusPage はバックエンドと同期データの現在状態を表示するページです。
+ * @responsibility 同期APIの状態を取得し、正常時と取得失敗時の案内を出し分ける。
+ */
+type StatusContentProps = {
+  status: SyncStatusResponse | null;
+  errorMessage?: string;
+};
+
+export function StatusContent({ status, errorMessage = "" }: StatusContentProps) {
+  const health = getHealthView(status?.syncHealth ?? "Unknown");
+
+  return (
+    <section className="rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm shadow-slate-200/60 sm:p-8 lg:p-10">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-amber-700">
+            Service Status
+          </p>
+          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">
+            Status
+          </h1>
+          <p className="mt-5 text-base leading-8 text-slate-600">
+            バックエンドAPIと、画面表示に使う価格・セッション・経済指標データの同期状態を確認できます。
+          </p>
+        </div>
+
+        <div className={`w-full rounded-2xl border p-5 lg:max-w-sm ${health.className}`}>
+          <div className="flex items-center gap-3">
+            <span className={`h-2.5 w-2.5 rounded-full ${health.dotClassName}`} />
+            <p className="text-sm font-semibold">{health.label}</p>
+          </div>
+          <p className="mt-3 text-sm leading-6">{health.description}</p>
+        </div>
+      </div>
+
+      {status ? (
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {buildStatusItems(status).map((item) => (
+            <article key={item.label} className="rounded-2xl border border-slate-200 bg-[#fbfaf7] p-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                {item.label}
+              </p>
+              <p className="mt-3 text-lg font-semibold text-slate-950">{item.value}</p>
+              <p className="mt-2 text-sm leading-6 text-slate-500">{item.description}</p>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-10 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm leading-7 text-rose-950">
+          {errorMessage || "同期ステータスの取得に失敗しました"}
+          。時間を置いて再読み込みし、解消しない場合はバックエンドAPIの起動状態を確認してください。
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default async function StatusPage() {
+  let status: SyncStatusResponse | null = null;
+  let errorMessage = "";
+
+  try {
+    status = await getSyncStatus();
+  } catch (error) {
+    errorMessage = error instanceof Error ? error.message : "同期ステータスの取得に失敗しました";
+  }
+
+  return <StatusContent status={status} errorMessage={errorMessage} />;
+}

--- a/apps/frontend/src/app/status/page.tsx
+++ b/apps/frontend/src/app/status/page.tsx
@@ -11,7 +11,11 @@ export const metadata: Metadata = {
   },
 };
 
-const formatDateTime = (value: string) => {
+/**
+ * formatDateTime は日時文字列を日本時間の読みやすい形式に変換します。
+ * @responsibility 空値や不正値を扱いながら、ja-JP ロケールで日時を整形する。
+ */
+function formatDateTime(value: string) {
   if (!value) {
     return "未取得";
   }
@@ -26,9 +30,13 @@ const formatDateTime = (value: string) => {
     timeStyle: "short",
     timeZone: "Asia/Tokyo",
   }).format(date);
-};
+}
 
-const getHealthView = (syncHealth: string) => {
+/**
+ * getHealthView は同期状態に応じた表示用データを返します。
+ * @responsibility ステータス文字列をラベル、説明文、Tailwind クラスにマッピングする。
+ */
+function getHealthView(syncHealth: string) {
   const normalized = syncHealth.toLowerCase();
 
   if (normalized === "healthy") {
@@ -55,40 +63,46 @@ const getHealthView = (syncHealth: string) => {
     className: "border-rose-200 bg-rose-50 text-rose-900",
     dotClassName: "bg-rose-500",
   };
-};
-
-const buildStatusItems = (status: SyncStatusResponse) => [
-  {
-    label: "Latest Candle",
-    value: formatDateTime(status.lastCandleAt),
-    description: "価格足データの最終同期時刻",
-  },
-  {
-    label: "Latest Session",
-    value: formatDateTime(status.lastSessionAt),
-    description: "セッション集計データの最終更新日",
-  },
-  {
-    label: "Latest Event",
-    value: formatDateTime(status.lastEventAt),
-    description: "経済指標データの最終同期時刻",
-  },
-  {
-    label: "Stored Candles",
-    value: status.totalCandles.toLocaleString("ja-JP"),
-    description: "バックエンドで確認できる価格足件数",
-  },
-];
+}
 
 /**
- * StatusPage はバックエンドと同期データの現在状態を表示するページです。
- * @responsibility 同期APIの状態を取得し、正常時と取得失敗時の案内を出し分ける。
+ * buildStatusItems は同期ステータスレスポンスを表示用の項目配列に変換します。
+ * @responsibility 各ステータス項目のラベル、フォーマット済み値、説明文を整理する。
  */
+function buildStatusItems(status: SyncStatusResponse) {
+  return [
+    {
+      label: "Latest Candle",
+      value: formatDateTime(status.lastCandleAt),
+      description: "価格足データの最終同期時刻",
+    },
+    {
+      label: "Latest Session",
+      value: formatDateTime(status.lastSessionAt),
+      description: "セッション集計データの最終更新日",
+    },
+    {
+      label: "Latest Event",
+      value: formatDateTime(status.lastEventAt),
+      description: "経済指標データの最終同期時刻",
+    },
+    {
+      label: "Stored Candles",
+      value: status.totalCandles.toLocaleString("ja-JP"),
+      description: "バックエンドで確認できる価格足件数",
+    },
+  ];
+}
+
 type StatusContentProps = {
   status: SyncStatusResponse | null;
   errorMessage?: string;
 };
 
+/**
+ * StatusContent はバックエンドと同期データの現在状態を表示するコンポーネントです。
+ * @responsibility 正常時と取得失敗時の表示内容を出し分ける。
+ */
 export function StatusContent({ status, errorMessage = "" }: StatusContentProps) {
   const health = getHealthView(status?.syncHealth ?? "Unknown");
 
@@ -138,6 +152,10 @@ export function StatusContent({ status, errorMessage = "" }: StatusContentProps)
   );
 }
 
+/**
+ * StatusPage はステータスページのルートコンポーネントです。
+ * @responsibility 同期ステータスを取得し、StatusContent に渡して表示する。
+ */
 export default async function StatusPage() {
   let status: SyncStatusResponse | null = null;
   let errorMessage = "";

--- a/apps/frontend/src/features/community/api/getCommunityThreads.test.ts
+++ b/apps/frontend/src/features/community/api/getCommunityThreads.test.ts
@@ -35,7 +35,7 @@ describe("getCommunityThreads", () => {
           id: "thread-1",
           title: "CPI発表前後のXAUUSDの値幅をどう見ていますか？",
           category: "Market Discussion",
-          excerpt: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
+          body: "前回CPIでは発表直後の初動より、NY後半の戻りが大きかったです。",
           replyCount: 12,
           createdAt: "2026-04-01T12:00:00Z",
         },

--- a/apps/frontend/src/features/sync/api/getSyncStatus.test.ts
+++ b/apps/frontend/src/features/sync/api/getSyncStatus.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { getSyncStatus } from "./getSyncStatus";
+
+let requestHeaders = new Headers();
+mock.module("next/headers", () => ({
+  headers: () => Promise.resolve(requestHeaders),
+}));
+
+const getMock = mock();
+mock.module("../../../lib/api/client", () => ({
+  apiClient: {
+    api: {
+      v1: {
+        sync: {
+          status: {
+            $get: getMock,
+          },
+        },
+      },
+    },
+  },
+}));
+
+describe("getSyncStatus", () => {
+  beforeEach(() => {
+    getMock.mockClear();
+    requestHeaders = new Headers();
+  });
+
+  it("正常に同期ステータスを取得できた場合、JSON データを返すこと", async () => {
+    const mockResponse = {
+      lastCandleAt: "2026-04-01T10:00:00Z",
+      lastSessionAt: "2026-04-01",
+      lastEventAt: "2026-04-01T10:00:00Z",
+      totalCandles: 10000,
+      syncHealth: "Healthy",
+    };
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await getSyncStatus();
+
+    expect(getMock).toHaveBeenCalled();
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("x-test-scenario ヘッダーがある場合、API 呼び出しへ転送すること", async () => {
+    requestHeaders = new Headers({ "x-test-scenario": "error" });
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        lastCandleAt: "",
+        lastSessionAt: "",
+        lastEventAt: "",
+        totalCandles: 0,
+        syncHealth: "Unknown",
+      }),
+    });
+
+    await getSyncStatus();
+
+    const init = getMock.mock.calls[0][1].init;
+    expect(init.headers["x-test-scenario"]).toBe("error");
+  });
+
+  it("API 呼び出しが失敗した場合、Error をスローすること", async () => {
+    getMock.mockResolvedValue({
+      ok: false,
+    });
+
+    expect(getSyncStatus()).rejects.toThrow("同期ステータスの取得に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/sync/api/getSyncStatus.ts
+++ b/apps/frontend/src/features/sync/api/getSyncStatus.ts
@@ -1,0 +1,25 @@
+import { headers } from 'next/headers';
+import { apiClient } from '../../../lib/api/client';
+
+/**
+ * getSyncStatus はバックエンドが把握している最新の同期状況を取得します。
+ * @responsibility Statusページで表示する同期ヘルスと最終更新時刻を返却する。
+ */
+export async function getSyncStatus() {
+  const headerList = await headers();
+  const scenario = headerList.get('x-test-scenario');
+  const initHeaders: HeadersInit = {};
+  if (scenario) {
+    initHeaders['x-test-scenario'] = scenario;
+  }
+
+  const res = await apiClient.api.v1.sync.status.$get(undefined, {
+    init: { cache: 'no-store', headers: initHeaders, signal: AbortSignal.timeout(5000) },
+  });
+
+  if (!res.ok) {
+    throw new Error('同期ステータスの取得に失敗しました');
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -16,6 +16,9 @@ export type AppClient = {
           $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<CommunityThreadsResponse> }>;
           $post: (args: { json: CreateCommunityThreadInput }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<CommunityThread> }>;
         };
+      };
+      sync: {
+        status: { $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<SyncStatusResponse> }> };
       }
     }
   }
@@ -77,6 +80,14 @@ export type CommunityThread = {
 
 export type CommunityThreadsResponse = {
   threads: CommunityThread[];
+};
+
+export type SyncStatusResponse = {
+  lastCandleAt: string;
+  lastSessionAt: string;
+  lastEventAt: string;
+  totalCandles: number;
+  syncHealth: string;
 };
 
 export type CreateCommunityThreadInput = {


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #42

# Todo

- [x] `/status` ページを追加し、バックエンドAPIと同期データの状態を表示
- [x] `/api/v1/sync/status` を呼び出すフロントAPIラッパーを追加
- [x] API取得失敗時に分かりやすい案内を表示
- [x] `/status` を sitemap に追加
- [x] Statusページ、同期ステータス取得、sitemap のテストを追加
- [x] 既存の掲示板APIテスト型不整合を修正し、型チェックを通過

# How to check (動作確認の手順)

```zsh
cd apps/frontend
bun test src/app/status/page.test.tsx src/features/sync/api/getSyncStatus.test.ts src/app/sitemap.test.ts
./node_modules/.bin/tsc --noEmit
bun run build

cd ../..
bun run lint:all
bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-08 10:46 (JST)
- ブランチ: feature/issue-42-status-page

```zsh
cd apps/frontend && bun test src/app/status/page.test.tsx src/features/sync/api/getSyncStatus.test.ts src/app/sitemap.test.ts
# 7 pass / 0 fail

cd apps/frontend && ./node_modules/.bin/tsc --noEmit
# pass

cd apps/frontend && bun run build
# pass (exit code 0)
# note: Wrangler emitted an EROFS log-file warning under /home/somah/.config/.wrangler/logs in the sandbox, but build completed successfully.

bun run lint:all
# frontend eslint: pass
# backend eslint: pass

bun run test:all
# frontend: 65 pass / 0 fail
# backend: 100 pass / 0 fail
```

</details>

# Related Links

- `/status`
- `/api/v1/sync/status`
