### PR TITLE
[FE] 考察ブログの記事一覧を実データ化する

### DIFF
--- a/apps/frontend/src/app/insights/[slug]/page.test.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import InsightDetailPage, { generateMetadata } from "./page";
+
+describe("InsightDetailPage", () => {
+  it("slugに対応する記事詳細を表示すること", async () => {
+    render(await InsightDetailPage({ params: Promise.resolve({ slug: "event-replay-checklist" }) }));
+
+    expect(screen.getByRole("heading", { name: "指標リプレイを見るときのチェックリスト" })).toBeDefined();
+    expect(screen.getByText("Research Note")).toBeDefined();
+    expect(screen.getByText(/毎回同じ観点で確認/)).toBeDefined();
+    expect(screen.getByRole("link", { name: "考察ブログ一覧へ戻る" }).getAttribute("href")).toBe("/insights");
+  });
+
+  it("存在しないslugの場合、案内を表示すること", async () => {
+    render(await InsightDetailPage({ params: Promise.resolve({ slug: "missing" }) }));
+
+    expect(screen.getByRole("heading", { name: "記事が見つかりません" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "考察ブログ一覧へ戻る" }).getAttribute("href")).toBe("/insights");
+  });
+
+  it("記事ごとのmetadataを生成すること", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ slug: "event-replay-checklist" }) });
+
+    expect(metadata.title).toBe("指標リプレイを見るときのチェックリスト");
+    expect(metadata.description).toContain("発表前レンジ");
+    expect(metadata.alternates).toEqual({ canonical: "/insights/event-replay-checklist" });
+    expect(metadata.openGraph).toEqual(expect.objectContaining({
+      type: "article",
+      url: "https://fanda-dev.com/insights/event-replay-checklist",
+      title: "指標リプレイを見るときのチェックリスト",
+      publishedTime: "2026-05-05",
+      locale: "ja_JP",
+    }));
+    expect(metadata.twitter).toEqual(expect.objectContaining({
+      card: "summary",
+      title: "指標リプレイを見るときのチェックリスト",
+    }));
+  });
+
+  it("存在しない記事のmetadataを生成すること", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ slug: "missing" }) });
+
+    expect(metadata.title).toBe("記事が見つかりません");
+  });
+});

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getInsightPostBySlug } from "@/features/insights/content";
+
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com").replace(/\/$/, "");
+
+type InsightDetailPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+const publishedDateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "medium",
+  timeZone: "Asia/Tokyo",
+});
+
+/**
+ * generateMetadata は考察記事詳細のメタ情報を生成します。
+ * @responsibility 記事タイトルと説明文をSEO metadataへ反映する。
+ */
+export async function generateMetadata({ params }: InsightDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getInsightPostBySlug(slug);
+
+  if (!post) {
+    return {
+      title: "記事が見つかりません",
+      description: "指定された考察ブログ記事は見つかりませんでした。",
+    };
+  }
+
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: {
+      canonical: `/insights/${post.slug}`,
+    },
+    openGraph: {
+      type: "article",
+      url: `${siteUrl}/insights/${post.slug}`,
+      title: post.title,
+      description: post.description,
+      publishedTime: post.publishedAt,
+      siteName: "fanda-dev",
+      locale: "ja_JP",
+    },
+    twitter: {
+      card: "summary",
+      title: post.title,
+      description: post.description,
+    },
+  };
+}
+
+/**
+ * InsightDetailPage は考察ブログの記事詳細を表示します。
+ * @responsibility slugに対応する記事本文と存在しない記事の案内を表示する。
+ */
+export default async function InsightDetailPage({ params }: InsightDetailPageProps) {
+  const { slug } = await params;
+  const post = getInsightPostBySlug(slug);
+
+  if (!post) {
+    return (
+      <section className="space-y-5 rounded-2xl border border-red-200 bg-red-50 p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-red-700">Insight Blog</p>
+        <h1 className="text-2xl font-semibold text-red-950">記事が見つかりません</h1>
+        <p className="text-sm leading-6 text-red-800">
+          指定された記事は存在しないか、公開が終了しています。考察ブログ一覧から記事を選び直してください。
+        </p>
+        <Link href="/insights" className="inline-flex rounded-xl bg-red-950 px-4 py-2 text-sm font-semibold text-white">
+          考察ブログ一覧へ戻る
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <article className="mx-auto max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60 lg:p-10">
+      <Link href="/insights" className="text-sm font-semibold text-amber-700 hover:text-amber-800">
+        考察ブログ一覧へ戻る
+      </Link>
+      <p className="mt-8 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">{post.category}</p>
+      <h1 className="mt-4 text-3xl font-semibold leading-tight text-slate-950 md:text-4xl">{post.title}</h1>
+      <time className="mt-4 block text-xs font-medium text-slate-400" dateTime={post.publishedAt}>
+        {publishedDateFormatter.format(new Date(post.publishedAt))}
+      </time>
+      <p className="mt-6 text-base leading-8 text-slate-600">{post.description}</p>
+      <div className="mt-8 space-y-6 border-t border-slate-100 pt-8">
+        {post.body.map((paragraph, index) => (
+          <p key={index} className="text-base leading-9 text-slate-700">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/src/app/insights/page.test.tsx
+++ b/apps/frontend/src/app/insights/page.test.tsx
@@ -20,6 +20,7 @@ describe("InsightsPage", () => {
     expect(screen.getByRole("link", { name: "テスト記事" }).getAttribute("href")).toBe("/insights/test-post");
     expect(screen.getByText("XAUUSD分析")).toBeDefined();
     expect(screen.getByText("テスト記事の抜粋です。")).toBeDefined();
+    expect(screen.getByText("2026年5月5日")).toBeDefined();
   });
 
   it("記事が0件の場合、空状態を表示すること", () => {

--- a/apps/frontend/src/app/insights/page.test.tsx
+++ b/apps/frontend/src/app/insights/page.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import InsightsPage, { metadata } from "./page";
+import type { InsightPost } from "@/features/insights/content";
+
+const post: InsightPost = {
+  slug: "test-post",
+  category: "XAUUSD分析",
+  title: "テスト記事",
+  description: "テスト記事の抜粋です。",
+  publishedAt: "2026-05-05",
+  body: ["本文です。"],
+};
+
+describe("InsightsPage", () => {
+  it("記事ソースから取得した記事一覧を表示すること", () => {
+    render(<InsightsPage getPosts={() => [post]} />);
+
+    expect(screen.getByRole("heading", { name: "XAUUSDとGOLD分析の考察を積み上げるブログ。" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "テスト記事" }).getAttribute("href")).toBe("/insights/test-post");
+    expect(screen.getByText("XAUUSD分析")).toBeDefined();
+    expect(screen.getByText("テスト記事の抜粋です。")).toBeDefined();
+  });
+
+  it("記事が0件の場合、空状態を表示すること", () => {
+    render(<InsightsPage getPosts={() => []} />);
+
+    expect(screen.getByText("まだ記事がありません")).toBeDefined();
+  });
+
+  it("記事取得に失敗した場合、エラー表示を出すこと", () => {
+    render(<InsightsPage getPosts={() => { throw new Error("failed"); }} />);
+
+    expect(screen.getByText("記事一覧を取得できませんでした")).toBeDefined();
+  });
+
+  it("SEO metadata が設定されていること", () => {
+    expect(metadata.title).toBe("考察ブログ");
+    expect(metadata.description).toContain("考察ブログ");
+  });
+});

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -15,6 +15,15 @@ type InsightPostsResult =
   | { status: "success"; posts: InsightPost[] }
   | { status: "error" };
 
+const publishedDateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "long",
+  timeZone: "Asia/Tokyo",
+});
+
+/**
+ * resolveInsightPosts は記事取得処理をラップし、成功または失敗の状態を返します。
+ * @responsibility 記事取得処理のエラーをハンドリングし、結果を統一された形式で提供する。
+ */
 function resolveInsightPosts(getPosts: () => InsightPost[]): InsightPostsResult {
   try {
     return { status: "success", posts: getPosts() };
@@ -75,10 +84,7 @@ export default function InsightsPage({ getPosts = getInsightPosts }: InsightsPag
                     </Link>
                   </h3>
                   <time className="mt-3 block text-xs font-medium text-slate-400" dateTime={post.publishedAt}>
-                    {new Intl.DateTimeFormat("ja-JP", {
-                      dateStyle: "medium",
-                      timeZone: "Asia/Tokyo",
-                    }).format(new Date(post.publishedAt))}
+                    {publishedDateFormatter.format(new Date(post.publishedAt))}
                   </time>
                   <p className="mt-4 text-sm leading-7 text-slate-600">{post.description}</p>
                 </article>

--- a/apps/frontend/src/app/insights/page.tsx
+++ b/apps/frontend/src/app/insights/page.tsx
@@ -1,33 +1,35 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { getInsightPosts, type InsightPost } from "@/features/insights/content";
 
 export const metadata: Metadata = {
   title: "考察ブログ",
-  description: "fanda-devのXAUUSD分析・GOLD分析の考察ブログのモックページです。",
+  description: "fanda-devのXAUUSD分析・GOLD分析の考察ブログです。",
 };
 
-const insightPosts = [
-  {
-    category: "XAUUSD分析",
-    title: "米CPIの日にゴールドが荒れやすい時間帯を整理する",
-    excerpt: "発表直後の初動だけでなく、ロンドンからNYにかけた流動性の変化を見ながら過去イベントを比較します。",
-  },
-  {
-    category: "GOLD分析",
-    title: "雇用統計後の戻りをセッション別に見る",
-    excerpt: "NFP直後のスプレッド拡大や一方向のブレイクだけでなく、その後の戻り幅を確認するための考察メモです。",
-  },
-  {
-    category: "Research Note",
-    title: "指標リプレイを見るときのチェックリスト",
-    excerpt: "発表前レンジ、初動の方向、5分後の反転、NY後半の継続性を同じ順番で確認します。",
-  },
-];
+type InsightsPageProps = {
+  getPosts?: () => InsightPost[];
+};
+
+type InsightPostsResult =
+  | { status: "success"; posts: InsightPost[] }
+  | { status: "error" };
+
+function resolveInsightPosts(getPosts: () => InsightPost[]): InsightPostsResult {
+  try {
+    return { status: "success", posts: getPosts() };
+  } catch {
+    return { status: "error" };
+  }
+}
 
 /**
- * InsightsPage は考察ブログのモックページを表示するコンポーネントです。
- * @responsibility 経済指標やボラティリティに関する分析記事の閲覧環境（モック）を提供する。
+ * InsightsPage は考察ブログの記事一覧ページです。
+ * @responsibility 記事ソースから取得した記事一覧、空状態、取得失敗を表示する。
  */
-export default function InsightsPage() {
+export default function InsightsPage({ getPosts = getInsightPosts }: InsightsPageProps = {}) {
+  const result = resolveInsightPosts(getPosts);
+
   return (
         <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white shadow-sm shadow-slate-200/60">
           <div className="border-b border-slate-100 p-6 lg:p-10">
@@ -38,23 +40,51 @@ export default function InsightsPage() {
               XAUUSDとGOLD分析の考察を積み上げるブログ。
             </h2>
             <p className="mt-5 max-w-2xl text-base leading-8 text-slate-600">
-              まだモックですが、経済指標ごとの値動きやセッション別ボラティリティの考察を記事として蓄積する場所です。
+              経済指標ごとの値動きやセッション別ボラティリティの考察を記事として蓄積する場所です。
             </p>
           </div>
 
-          <div className="grid gap-0 md:grid-cols-3">
-            {insightPosts.map((post) => (
-              <article key={post.title} className="border-b border-slate-100 p-6 md:border-b-0 md:border-r md:last:border-r-0 lg:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">
-                  {post.category}
+          {result.status === "error" ? (
+            <div className="p-6 lg:p-8">
+              <div className="rounded-2xl border border-red-200 bg-red-50 p-6">
+                <h3 className="text-lg font-semibold text-red-950">記事一覧を取得できませんでした</h3>
+                <p className="mt-3 text-sm leading-6 text-red-800">
+                  時間をおいて再度お試しください。記事ソースの設定に問題がある場合は、運用ドキュメントを確認してください。
                 </p>
-                <h3 className="mt-4 text-xl font-semibold leading-8 text-slate-950">
-                  {post.title}
-                </h3>
-                <p className="mt-4 text-sm leading-7 text-slate-600">{post.excerpt}</p>
-              </article>
-            ))}
-          </div>
+              </div>
+            </div>
+          ) : result.posts.length === 0 ? (
+            <div className="p-6 lg:p-8">
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-[#fbfaf7] p-6 text-center">
+                <h3 className="text-lg font-semibold text-slate-950">まだ記事がありません</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-600">
+                  XAUUSD分析やGOLD分析の記事が公開されると、ここに一覧表示されます。
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="grid gap-0 md:grid-cols-3">
+              {result.posts.map((post) => (
+                <article key={post.slug} className="border-b border-slate-100 p-6 md:border-b-0 md:border-r md:last:border-r-0 lg:p-8">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">
+                    {post.category}
+                  </p>
+                  <h3 className="mt-4 text-xl font-semibold leading-8 text-slate-950">
+                    <Link href={`/insights/${post.slug}`} className="hover:text-amber-700">
+                      {post.title}
+                    </Link>
+                  </h3>
+                  <time className="mt-3 block text-xs font-medium text-slate-400" dateTime={post.publishedAt}>
+                    {new Intl.DateTimeFormat("ja-JP", {
+                      dateStyle: "medium",
+                      timeZone: "Asia/Tokyo",
+                    }).format(new Date(post.publishedAt))}
+                  </time>
+                  <p className="mt-4 text-sm leading-7 text-slate-600">{post.description}</p>
+                </article>
+              ))}
+            </div>
+          )}
         </section>
   );
 }

--- a/apps/frontend/src/app/sitemap.test.ts
+++ b/apps/frontend/src/app/sitemap.test.ts
@@ -10,4 +10,13 @@ describe("sitemap", () => {
     expect(urls).toContain("https://fanda-dev.com/api-docs");
     expect(urls).toContain("https://fanda-dev.com/status");
   });
+
+  it("考察ブログの記事URLを含むこと", () => {
+    const items = sitemap();
+    const urls = items.map((item) => item.url);
+
+    expect(urls).toContain("https://fanda-dev.com/insights/event-replay-checklist");
+    expect(urls).toContain("https://fanda-dev.com/insights/gold-nfp-reversal-by-session");
+    expect(items.find((item) => item.url.endsWith("/insights/event-replay-checklist"))?.priority).toBe(0.7);
+  });
 });

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { getInsightPosts } from "@/features/insights/content";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
 
@@ -7,7 +8,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
  * @responsibility サイト内の主要な URL 一覧を定義し、インデックス登録を補助する。
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+  const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: siteUrl,
       lastModified: new Date(),
@@ -33,4 +34,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
   ];
+
+  const insightRoutes: MetadataRoute.Sitemap = getInsightPosts().map((post) => ({
+    url: `${siteUrl}/insights/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...insightRoutes];
 }

--- a/apps/frontend/src/features/insights/content.test.ts
+++ b/apps/frontend/src/features/insights/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getInsightPosts } from "./content";
+import { getInsightPostBySlug, getInsightPosts } from "./content";
 
 describe("insights content", () => {
   it("公開日が新しい順で記事一覧を返すこと", () => {
@@ -20,5 +20,28 @@ describe("insights content", () => {
     expect(post.title).toBeTruthy();
     expect(post.description).toBeTruthy();
     expect(post.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("slugで記事を取得できること", () => {
+    const post = getInsightPostBySlug("event-replay-checklist");
+
+    expect(post?.title).toBe("指標リプレイを見るときのチェックリスト");
+  });
+
+  it("存在しないslugの場合 null を返すこと", () => {
+    expect(getInsightPostBySlug("missing")).toBeNull();
+  });
+
+  it("取得した記事オブジェクトを変更しても元のデータに影響しないこと", () => {
+    const post = getInsightPostBySlug("event-replay-checklist");
+    if (post) {
+      post.title = "MODIFIED";
+      post.body.push("NEW PARAGRAPH");
+    }
+
+    const original = getInsightPostBySlug("event-replay-checklist");
+
+    expect(original?.title).not.toBe("MODIFIED");
+    expect(original?.body).not.toContain("NEW PARAGRAPH");
   });
 });

--- a/apps/frontend/src/features/insights/content.test.ts
+++ b/apps/frontend/src/features/insights/content.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { getInsightPosts } from "./content";
+
+describe("insights content", () => {
+  it("公開日が新しい順で記事一覧を返すこと", () => {
+    const posts = getInsightPosts();
+
+    expect(posts.map((post) => post.slug)).toEqual([
+      "event-replay-checklist",
+      "gold-nfp-reversal-by-session",
+      "xauusd-cpi-session-volatility",
+    ]);
+  });
+
+  it("一覧表示に必要なメタ情報を持つこと", () => {
+    const [post] = getInsightPosts();
+
+    expect(post.slug).toBeTruthy();
+    expect(post.category).toBeTruthy();
+    expect(post.title).toBeTruthy();
+    expect(post.description).toBeTruthy();
+    expect(post.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -7,7 +7,7 @@ export type InsightPost = {
   body: string[];
 };
 
-export const insightPosts: InsightPost[] = [
+const insightPosts: InsightPost[] = [
   {
     slug: "xauusd-cpi-session-volatility",
     category: "XAUUSD分析",

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -1,0 +1,55 @@
+export type InsightPost = {
+  slug: string;
+  category: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  body: string[];
+};
+
+export const insightPosts: InsightPost[] = [
+  {
+    slug: "xauusd-cpi-session-volatility",
+    category: "XAUUSD分析",
+    title: "米CPIの日にゴールドが荒れやすい時間帯を整理する",
+    description: "発表直後の初動だけでなく、ロンドンからNYにかけた流動性の変化を見ながら過去イベントを比較します。",
+    publishedAt: "2026-05-01",
+    body: [
+      "米CPIの発表日は、発表直後の値幅だけでなく、その後のセッション推移まで確認すると値動きの特徴を整理しやすくなります。",
+      "初動で大きく伸びた方向がそのまま続く場合もありますが、NY後半にかけて戻りが入るケースもあります。",
+      "過去イベントのリプレイでは、発表前レンジ、初動の高値安値、5分後の反転、NY後半の継続性を同じ順番で確認します。",
+    ],
+  },
+  {
+    slug: "gold-nfp-reversal-by-session",
+    category: "GOLD分析",
+    title: "雇用統計後の戻りをセッション別に見る",
+    description: "NFP直後のスプレッド拡大や一方向のブレイクだけでなく、その後の戻り幅を確認するための考察メモです。",
+    publishedAt: "2026-05-03",
+    body: [
+      "雇用統計後のGOLDは、初動の方向だけで判断すると戻りに巻き込まれやすくなります。",
+      "ロンドン時間からNY前半までのレンジと、発表後にどの程度レンジ外へ進んだかを分けて見ると、反転の強さを比較できます。",
+      "戻り幅をセッション別に記録しておくと、次回のイベント前に利確や追随の判断材料として使いやすくなります。",
+    ],
+  },
+  {
+    slug: "event-replay-checklist",
+    category: "Research Note",
+    title: "指標リプレイを見るときのチェックリスト",
+    description: "発表前レンジ、初動の方向、5分後の反転、NY後半の継続性を同じ順番で確認します。",
+    publishedAt: "2026-05-05",
+    body: [
+      "指標リプレイを見るときは、毎回同じ観点で確認するとイベント間の比較がしやすくなります。",
+      "発表前レンジ、初動の方向、5分後の反転、NY後半の継続性を順番に確認します。",
+      "見た内容はリサーチメモへ残し、次のイベント前に仮説として見返せる状態にします。",
+    ],
+  },
+];
+
+/**
+ * getInsightPosts は公開済み考察記事を新しい順で返します。
+ * @responsibility 記事一覧ページが記事ソースの保持形式へ依存しないようにする。
+ */
+export function getInsightPosts(): InsightPost[] {
+  return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+}

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -7,6 +7,17 @@ export type InsightPost = {
   body: string[];
 };
 
+/**
+ * copyInsightPost は記事データを呼び出し側で変更しても元データへ影響しない形で返します。
+ * @responsibility 記事ソースの不変性を保ち、一覧・詳細の利用側が安全に表示データを扱えるようにする。
+ */
+function copyInsightPost(post: InsightPost): InsightPost {
+  return {
+    ...post,
+    body: [...post.body],
+  };
+}
+
 const insightPosts: InsightPost[] = [
   {
     slug: "xauusd-cpi-session-volatility",
@@ -51,5 +62,14 @@ const insightPosts: InsightPost[] = [
  * @responsibility 記事一覧ページが記事ソースの保持形式へ依存しないようにする。
  */
 export function getInsightPosts(): InsightPost[] {
-  return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt)).map(copyInsightPost);
+}
+
+/**
+ * getInsightPostBySlug はslugに一致する考察記事を返します。
+ * @responsibility 詳細ページが記事ソースの保持形式へ依存しないようにする。
+ */
+export function getInsightPostBySlug(slug: string): InsightPost | null {
+  const post = insightPosts.find((item) => item.slug === slug);
+  return post ? copyInsightPost(post) : null;
 }


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #34

# Todo

- [x] ADR #0005 に沿って型付き記事ソースを追加
- [x] `/insights` の固定配列を記事ソース取得に置き換え
- [x] カテゴリ、タイトル、抜粋、公開日を表示
- [x] 記事が0件の場合の空状態を追加
- [x] 記事取得失敗時のエラー表示を追加
- [x] 記事ソースと一覧ページのテストを追加

# How to check (動作確認の手順)

```zsh
cd apps/frontend
bun test src/features/insights/content.test.ts src/app/insights/page.test.tsx
./node_modules/.bin/tsc --noEmit
bun run lint
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-09 14:09 JST
- ブランチ: feature/issue-34-insights-list-data

```zsh
bun test ...
# 6 pass / 0 fail

./node_modules/.bin/tsc --noEmit
# pass

bun run lint
# pass

git commit hook
# lint:frontend pass
# lint:backend pass
```

</details>

# Related Links

- Stacked on: #99
- Depends on: #33
