### PR TITLE
[FE] 考察ブログの記事詳細ページを実装する

### DIFF
--- a/apps/frontend/src/app/insights/[slug]/page.test.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import InsightDetailPage, { generateMetadata } from "./page";
+
+describe("InsightDetailPage", () => {
+  it("slugに対応する記事詳細を表示すること", async () => {
+    render(await InsightDetailPage({ params: Promise.resolve({ slug: "event-replay-checklist" }) }));
+
+    expect(screen.getByRole("heading", { name: "指標リプレイを見るときのチェックリスト" })).toBeDefined();
+    expect(screen.getByText("Research Note")).toBeDefined();
+    expect(screen.getByText(/毎回同じ観点で確認/)).toBeDefined();
+    expect(screen.getByRole("link", { name: "考察ブログ一覧へ戻る" }).getAttribute("href")).toBe("/insights");
+  });
+
+  it("存在しないslugの場合、案内を表示すること", async () => {
+    render(await InsightDetailPage({ params: Promise.resolve({ slug: "missing" }) }));
+
+    expect(screen.getByRole("heading", { name: "記事が見つかりません" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "考察ブログ一覧へ戻る" }).getAttribute("href")).toBe("/insights");
+  });
+
+  it("記事ごとのmetadataを生成すること", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ slug: "event-replay-checklist" }) });
+
+    expect(metadata.title).toBe("指標リプレイを見るときのチェックリスト");
+    expect(metadata.description).toContain("発表前レンジ");
+    expect(metadata.alternates).toEqual({ canonical: "/insights/event-replay-checklist" });
+  });
+
+  it("存在しない記事のmetadataを生成すること", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ slug: "missing" }) });
+
+    expect(metadata.title).toBe("記事が見つかりません");
+  });
+});

--- a/apps/frontend/src/app/insights/[slug]/page.test.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.test.tsx
@@ -25,6 +25,17 @@ describe("InsightDetailPage", () => {
     expect(metadata.title).toBe("指標リプレイを見るときのチェックリスト");
     expect(metadata.description).toContain("発表前レンジ");
     expect(metadata.alternates).toEqual({ canonical: "/insights/event-replay-checklist" });
+    expect(metadata.openGraph).toEqual(expect.objectContaining({
+      type: "article",
+      url: "https://fanda-dev.com/insights/event-replay-checklist",
+      title: "指標リプレイを見るときのチェックリスト",
+      publishedTime: "2026-05-05",
+      locale: "ja_JP",
+    }));
+    expect(metadata.twitter).toEqual(expect.objectContaining({
+      card: "summary",
+      title: "指標リプレイを見るときのチェックリスト",
+    }));
   });
 
   it("存在しない記事のmetadataを生成すること", async () => {

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -6,6 +6,11 @@ type InsightDetailPageProps = {
   params: Promise<{ slug: string }>;
 };
 
+const publishedDateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "medium",
+  timeZone: "Asia/Tokyo",
+});
+
 /**
  * generateMetadata は考察記事詳細のメタ情報を生成します。
  * @responsibility 記事タイトルと説明文をSEO metadataへ反映する。
@@ -61,15 +66,12 @@ export default async function InsightDetailPage({ params }: InsightDetailPagePro
       <p className="mt-8 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">{post.category}</p>
       <h1 className="mt-4 text-3xl font-semibold leading-tight text-slate-950 md:text-4xl">{post.title}</h1>
       <time className="mt-4 block text-xs font-medium text-slate-400" dateTime={post.publishedAt}>
-        {new Intl.DateTimeFormat("ja-JP", {
-          dateStyle: "medium",
-          timeZone: "Asia/Tokyo",
-        }).format(new Date(post.publishedAt))}
+        {publishedDateFormatter.format(new Date(post.publishedAt))}
       </time>
       <p className="mt-6 text-base leading-8 text-slate-600">{post.description}</p>
       <div className="mt-8 space-y-6 border-t border-slate-100 pt-8">
-        {post.body.map((paragraph) => (
-          <p key={paragraph} className="text-base leading-9 text-slate-700">
+        {post.body.map((paragraph, index) => (
+          <p key={index} className="text-base leading-9 text-slate-700">
             {paragraph}
           </p>
         ))}

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getInsightPostBySlug } from "@/features/insights/content";
+
+type InsightDetailPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+/**
+ * generateMetadata は考察記事詳細のメタ情報を生成します。
+ * @responsibility 記事タイトルと説明文をSEO metadataへ反映する。
+ */
+export async function generateMetadata({ params }: InsightDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getInsightPostBySlug(slug);
+
+  if (!post) {
+    return {
+      title: "記事が見つかりません",
+      description: "指定された考察ブログ記事は見つかりませんでした。",
+    };
+  }
+
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: {
+      canonical: `/insights/${post.slug}`,
+    },
+  };
+}
+
+/**
+ * InsightDetailPage は考察ブログの記事詳細を表示します。
+ * @responsibility slugに対応する記事本文と存在しない記事の案内を表示する。
+ */
+export default async function InsightDetailPage({ params }: InsightDetailPageProps) {
+  const { slug } = await params;
+  const post = getInsightPostBySlug(slug);
+
+  if (!post) {
+    return (
+      <section className="space-y-5 rounded-2xl border border-red-200 bg-red-50 p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-red-700">Insight Blog</p>
+        <h1 className="text-2xl font-semibold text-red-950">記事が見つかりません</h1>
+        <p className="text-sm leading-6 text-red-800">
+          指定された記事は存在しないか、公開が終了しています。考察ブログ一覧から記事を選び直してください。
+        </p>
+        <Link href="/insights" className="inline-flex rounded-xl bg-red-950 px-4 py-2 text-sm font-semibold text-white">
+          考察ブログ一覧へ戻る
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <article className="mx-auto max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60 lg:p-10">
+      <Link href="/insights" className="text-sm font-semibold text-amber-700 hover:text-amber-800">
+        考察ブログ一覧へ戻る
+      </Link>
+      <p className="mt-8 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">{post.category}</p>
+      <h1 className="mt-4 text-3xl font-semibold leading-tight text-slate-950 md:text-4xl">{post.title}</h1>
+      <time className="mt-4 block text-xs font-medium text-slate-400" dateTime={post.publishedAt}>
+        {new Intl.DateTimeFormat("ja-JP", {
+          dateStyle: "medium",
+          timeZone: "Asia/Tokyo",
+        }).format(new Date(post.publishedAt))}
+      </time>
+      <p className="mt-6 text-base leading-8 text-slate-600">{post.description}</p>
+      <div className="mt-8 space-y-6 border-t border-slate-100 pt-8">
+        {post.body.map((paragraph) => (
+          <p key={paragraph} className="text-base leading-9 text-slate-700">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getInsightPostBySlug } from "@/features/insights/content";
 
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com").replace(/\/$/, "");
+
 type InsightDetailPageProps = {
   params: Promise<{ slug: string }>;
 };
@@ -31,6 +33,20 @@ export async function generateMetadata({ params }: InsightDetailPageProps): Prom
     description: post.description,
     alternates: {
       canonical: `/insights/${post.slug}`,
+    },
+    openGraph: {
+      type: "article",
+      url: `${siteUrl}/insights/${post.slug}`,
+      title: post.title,
+      description: post.description,
+      publishedTime: post.publishedAt,
+      siteName: "fanda-dev",
+      locale: "ja_JP",
+    },
+    twitter: {
+      card: "summary",
+      title: post.title,
+      description: post.description,
     },
   };
 }

--- a/apps/frontend/src/app/sitemap.test.ts
+++ b/apps/frontend/src/app/sitemap.test.ts
@@ -10,4 +10,13 @@ describe("sitemap", () => {
     expect(urls).toContain("https://fanda-dev.com/api-docs");
     expect(urls).toContain("https://fanda-dev.com/status");
   });
+
+  it("考察ブログの記事URLを含むこと", () => {
+    const items = sitemap();
+    const urls = items.map((item) => item.url);
+
+    expect(urls).toContain("https://fanda-dev.com/insights/event-replay-checklist");
+    expect(urls).toContain("https://fanda-dev.com/insights/gold-nfp-reversal-by-session");
+    expect(items.find((item) => item.url.endsWith("/insights/event-replay-checklist"))?.priority).toBe(0.7);
+  });
 });

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { getInsightPosts } from "@/features/insights/content";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
 
@@ -7,7 +8,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
  * @responsibility サイト内の主要な URL 一覧を定義し、インデックス登録を補助する。
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+  const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: siteUrl,
       lastModified: new Date(),
@@ -33,4 +34,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
   ];
+
+  const insightRoutes: MetadataRoute.Sitemap = getInsightPosts().map((post) => ({
+    url: `${siteUrl}/insights/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...insightRoutes];
 }

--- a/apps/frontend/src/features/insights/content.test.ts
+++ b/apps/frontend/src/features/insights/content.test.ts
@@ -31,4 +31,17 @@ describe("insights content", () => {
   it("存在しないslugの場合 null を返すこと", () => {
     expect(getInsightPostBySlug("missing")).toBeNull();
   });
+
+  it("取得した記事オブジェクトを変更しても元のデータに影響しないこと", () => {
+    const post = getInsightPostBySlug("event-replay-checklist");
+    if (post) {
+      post.title = "MODIFIED";
+      post.body.push("NEW PARAGRAPH");
+    }
+
+    const original = getInsightPostBySlug("event-replay-checklist");
+
+    expect(original?.title).not.toBe("MODIFIED");
+    expect(original?.body).not.toContain("NEW PARAGRAPH");
+  });
 });

--- a/apps/frontend/src/features/insights/content.test.ts
+++ b/apps/frontend/src/features/insights/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getInsightPosts } from "./content";
+import { getInsightPostBySlug, getInsightPosts } from "./content";
 
 describe("insights content", () => {
   it("公開日が新しい順で記事一覧を返すこと", () => {
@@ -20,5 +20,15 @@ describe("insights content", () => {
     expect(post.title).toBeTruthy();
     expect(post.description).toBeTruthy();
     expect(post.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("slugで記事を取得できること", () => {
+    const post = getInsightPostBySlug("event-replay-checklist");
+
+    expect(post?.title).toBe("指標リプレイを見るときのチェックリスト");
+  });
+
+  it("存在しないslugの場合 null を返すこと", () => {
+    expect(getInsightPostBySlug("missing")).toBeNull();
   });
 });

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -53,3 +53,11 @@ export const insightPosts: InsightPost[] = [
 export function getInsightPosts(): InsightPost[] {
   return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
 }
+
+/**
+ * getInsightPostBySlug はslugに一致する考察記事を返します。
+ * @responsibility 詳細ページが記事ソースの保持形式へ依存しないようにする。
+ */
+export function getInsightPostBySlug(slug: string): InsightPost | null {
+  return insightPosts.find((post) => post.slug === slug) ?? null;
+}

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -7,6 +7,10 @@ export type InsightPost = {
   body: string[];
 };
 
+/**
+ * copyInsightPost は記事データを呼び出し側で変更しても元データへ影響しない形で返します。
+ * @responsibility 記事ソースの不変性を保ち、一覧・詳細の利用側が安全に表示データを扱えるようにする。
+ */
 function copyInsightPost(post: InsightPost): InsightPost {
   return {
     ...post,

--- a/apps/frontend/src/features/insights/content.ts
+++ b/apps/frontend/src/features/insights/content.ts
@@ -7,6 +7,13 @@ export type InsightPost = {
   body: string[];
 };
 
+function copyInsightPost(post: InsightPost): InsightPost {
+  return {
+    ...post,
+    body: [...post.body],
+  };
+}
+
 const insightPosts: InsightPost[] = [
   {
     slug: "xauusd-cpi-session-volatility",
@@ -51,7 +58,7 @@ const insightPosts: InsightPost[] = [
  * @responsibility 記事一覧ページが記事ソースの保持形式へ依存しないようにする。
  */
 export function getInsightPosts(): InsightPost[] {
-  return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  return [...insightPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt)).map(copyInsightPost);
 }
 
 /**
@@ -59,5 +66,6 @@ export function getInsightPosts(): InsightPost[] {
  * @responsibility 詳細ページが記事ソースの保持形式へ依存しないようにする。
  */
 export function getInsightPostBySlug(slug: string): InsightPost | null {
-  return insightPosts.find((post) => post.slug === slug) ?? null;
+  const post = insightPosts.find((item) => item.slug === slug);
+  return post ? copyInsightPost(post) : null;
 }


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #35

# Todo

- [x] `/insights/[slug]` 詳細ページを追加
- [x] 記事一覧から詳細ページへ遷移するslugリンクを利用
- [x] 記事タイトル、公開日、カテゴリ、本文を表示
- [x] 存在しないslugの場合の案内を表示
- [x] 記事ごとのmetadata/canonical生成を追加
- [x] 記事詳細とcontent取得のテストを追加

# How to check (動作確認の手順)

```zsh
cd apps/frontend
bun test src/features/insights/content.test.ts 'src/app/insights/[slug]/page.test.tsx'
./node_modules/.bin/tsc --noEmit
bun run lint
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-09 14:09 JST
- ブランチ: feature/issue-35-insights-detail-page

```zsh
bun test ...
# 8 pass / 0 fail

./node_modules/.bin/tsc --noEmit
# pass

bun run lint
# pass

git commit hook
# lint:frontend pass
# lint:backend pass
```

</details>

# Related Links

- Stacked on: #100
- Depends on: #34
