### PR TITLE
[SEO] 考察ブログの記事ごとのメタ情報とサイトマップを整備する

### DIFF
--- a/apps/frontend/src/app/insights/[slug]/page.test.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.test.tsx
@@ -30,6 +30,7 @@ describe("InsightDetailPage", () => {
       url: "https://fanda-dev.com/insights/event-replay-checklist",
       title: "指標リプレイを見るときのチェックリスト",
       publishedTime: "2026-05-05",
+      locale: "ja_JP",
     }));
     expect(metadata.twitter).toEqual(expect.objectContaining({
       card: "summary",

--- a/apps/frontend/src/app/insights/[slug]/page.test.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.test.tsx
@@ -25,6 +25,16 @@ describe("InsightDetailPage", () => {
     expect(metadata.title).toBe("指標リプレイを見るときのチェックリスト");
     expect(metadata.description).toContain("発表前レンジ");
     expect(metadata.alternates).toEqual({ canonical: "/insights/event-replay-checklist" });
+    expect(metadata.openGraph).toEqual(expect.objectContaining({
+      type: "article",
+      url: "https://fanda-dev.com/insights/event-replay-checklist",
+      title: "指標リプレイを見るときのチェックリスト",
+      publishedTime: "2026-05-05",
+    }));
+    expect(metadata.twitter).toEqual(expect.objectContaining({
+      card: "summary",
+      title: "指標リプレイを見るときのチェックリスト",
+    }));
   });
 
   it("存在しない記事のmetadataを生成すること", async () => {

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getInsightPostBySlug } from "@/features/insights/content";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
+
 type InsightDetailPageProps = {
   params: Promise<{ slug: string }>;
 };
@@ -26,6 +28,19 @@ export async function generateMetadata({ params }: InsightDetailPageProps): Prom
     description: post.description,
     alternates: {
       canonical: `/insights/${post.slug}`,
+    },
+    openGraph: {
+      type: "article",
+      url: `${siteUrl}/insights/${post.slug}`,
+      title: post.title,
+      description: post.description,
+      publishedTime: post.publishedAt,
+      siteName: "fanda-dev",
+    },
+    twitter: {
+      card: "summary",
+      title: post.title,
+      description: post.description,
     },
   };
 }

--- a/apps/frontend/src/app/insights/[slug]/page.tsx
+++ b/apps/frontend/src/app/insights/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getInsightPostBySlug } from "@/features/insights/content";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com").replace(/\/$/, "");
 
 type InsightDetailPageProps = {
   params: Promise<{ slug: string }>;
@@ -41,6 +41,7 @@ export async function generateMetadata({ params }: InsightDetailPageProps): Prom
       description: post.description,
       publishedTime: post.publishedAt,
       siteName: "fanda-dev",
+      locale: "ja_JP",
     },
     twitter: {
       card: "summary",

--- a/apps/frontend/src/app/sitemap.test.ts
+++ b/apps/frontend/src/app/sitemap.test.ts
@@ -10,4 +10,13 @@ describe("sitemap", () => {
     expect(urls).toContain("https://fanda-dev.com/api-docs");
     expect(urls).toContain("https://fanda-dev.com/status");
   });
+
+  it("考察ブログの記事URLを含むこと", () => {
+    const items = sitemap();
+    const urls = items.map((item) => item.url);
+
+    expect(urls).toContain("https://fanda-dev.com/insights/event-replay-checklist");
+    expect(urls).toContain("https://fanda-dev.com/insights/gold-nfp-reversal-by-session");
+    expect(items.find((item) => item.url.endsWith("/insights/event-replay-checklist"))?.priority).toBe(0.7);
+  });
 });

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { getInsightPosts } from "@/features/insights/content";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
 
@@ -7,7 +8,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://fanda-dev.com";
  * @responsibility サイト内の主要な URL 一覧を定義し、インデックス登録を補助する。
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+  const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: siteUrl,
       lastModified: new Date(),
@@ -33,4 +34,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
   ];
+
+  const insightRoutes: MetadataRoute.Sitemap = getInsightPosts().map((post) => ({
+    url: `${siteUrl}/insights/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...insightRoutes];
 }


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #36

# Todo

- [x] 記事ごとのtitle/descriptionをmetadataへ反映
- [x] 記事ごとのcanonical URLを設定
- [x] OGP/Twitter Cardを記事内容に合わせて出力
- [x] sitemapに記事URLを追加
- [x] metadataとsitemapのテストを追加

# How to check (動作確認の手順)

```zsh
cd apps/frontend
bun test 'src/app/insights/[slug]/page.test.tsx' src/app/sitemap.test.ts
./node_modules/.bin/tsc --noEmit
bun run lint
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-09 14:09 JST
- ブランチ: feature/issue-36-insights-seo-sitemap

```zsh
bun test ...
# 6 pass / 0 fail

./node_modules/.bin/tsc --noEmit
# pass

bun run lint
# pass

git commit hook
# lint:frontend pass
# lint:backend pass
```

</details>

# Related Links

- Stacked on: #101
- Depends on: #35
