### PR TITLE
[BE] リサーチメモの保存APIを実装する

### DIFF
--- a/apps/backend/migrations/0004_dry_magdalene.sql
+++ b/apps/backend/migrations/0004_dry_magdalene.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "research_notes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_research_notes_created" ON "research_notes" USING btree ("created_at");

--- a/apps/backend/migrations/meta/0004_snapshot.json
+++ b/apps/backend/migrations/meta/0004_snapshot.json
@@ -1,0 +1,918 @@
+{
+  "id": "ce3a4327-bcc7-4f3a-9866-c5c41fef828a",
+  "prevId": "289b3d01-5f22-4f24-965b-8bdb17aa6ed9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_replies": {
+      "name": "community_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_community_replies_thread_created": {
+          "name": "idx_community_replies_thread_created",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_replies_thread_id_community_threads_id_fk": {
+          "name": "community_replies_thread_id_community_threads_id_fk",
+          "tableFrom": "community_replies",
+          "tableTo": "community_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_threads": {
+      "name": "community_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'General'"
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.economic_events": {
+      "name": "economic_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "economic_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "datetime_jst": {
+          "name": "datetime_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual": {
+          "name": "actual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forecast": {
+          "name": "forecast",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous": {
+          "name": "previous",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_name_datetime": {
+          "name": "idx_events_name_datetime",
+          "columns": [
+            {
+              "expression": "datetime_jst",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_candles": {
+      "name": "price_candles",
+      "schema": "",
+      "columns": {
+        "datetime_jst": {
+          "name": "datetime_jst",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_price": {
+          "name": "open_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_price": {
+          "name": "high_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low_price": {
+          "name": "low_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_price": {
+          "name": "close_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "open": {
+          "name": "open",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high": {
+          "name": "high",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low": {
+          "name": "low",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close": {
+          "name": "close",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.research_notes": {
+      "name": "research_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_research_notes_created": {
+          "name": "idx_research_notes_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_thresholds": {
+      "name": "session_thresholds",
+      "schema": "",
+      "columns": {
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "small_threshold": {
+          "name": "small_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "large_threshold": {
+          "name": "large_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_volatilities": {
+      "name": "session_volatilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "session_volatilities_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time_jst": {
+          "name": "start_time_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time_jst": {
+          "name": "end_time_jst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volatility_points": {
+          "name": "volatility_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_event": {
+          "name": "has_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_high_impact_event": {
+          "name": "has_high_impact_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "events_linked": {
+          "name": "events_linked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_session_date_name": {
+          "name": "idx_session_date_name",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_candle_at": {
+          "name": "last_candle_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_session_at": {
+          "name": "last_session_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_candles": {
+          "name": "total_candles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_health": {
+          "name": "sync_health",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Healthy'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zigzag_points": {
+      "name": "zigzag_points",
+      "schema": "",
+      "columns": {
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778073129485,
       "tag": "0003_adorable_bill_hollister",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778401100634,
+      "tag": "0004_dry_magdalene",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'bun:test';
 import { CalculateZigZagUseCase } from '../application/use_case/calculateZigZagUseCase';
 import { CreateCommunityReplyUseCase } from '../application/use_case/createCommunityReplyUseCase';
 import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
+import { CreateResearchNoteUseCase } from '../application/use_case/createResearchNoteUseCase';
 import { GetCommunityThreadDetailUseCase } from '../application/use_case/getCommunityThreadDetailUseCase';
 import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
 import { GetLatestPriceUseCase } from '../application/use_case/getLatestPriceUseCase';
 import { GetRecentEventNamesUseCase } from '../application/use_case/getRecentEventNamesUseCase';
 import { GetRecentSessionsWithAutoSyncUseCase } from '../application/use_case/getRecentSessionsWithAutoSyncUseCase';
 import { GetReplayDataUseCase } from '../application/use_case/getReplayDataUseCase';
+import { GetResearchNotesUseCase } from '../application/use_case/getResearchNotesUseCase';
 import { GetSyncStatusUseCase } from '../application/use_case/getSyncStatusUseCase';
 import { createAppContainer, freezeAppContainer } from './container';
 import { createMockDrizzle } from '../interface/test/testHelpers';
@@ -17,12 +19,15 @@ describe('createAppContainer', () => {
     const container = createAppContainer(createMockDrizzle());
 
     expect(container.repositories.communityThreadRepo).toBeDefined();
+    expect(container.repositories.researchNoteRepo).toBeDefined();
     expect(container.repositories.priceRepo).toBeDefined();
     expect(container.repositories.syncRepo).toBeDefined();
     expect(container.useCases.community.getThreads).toBeInstanceOf(GetCommunityThreadsUseCase);
     expect(container.useCases.community.getThreadDetail).toBeInstanceOf(GetCommunityThreadDetailUseCase);
     expect(container.useCases.community.createThread).toBeInstanceOf(CreateCommunityThreadUseCase);
     expect(container.useCases.community.createReply).toBeInstanceOf(CreateCommunityReplyUseCase);
+    expect(container.useCases.researchNotes.getNotes).toBeInstanceOf(GetResearchNotesUseCase);
+    expect(container.useCases.researchNotes.createNote).toBeInstanceOf(CreateResearchNoteUseCase);
     expect(container.useCases.sync.getStatus).toBeInstanceOf(GetSyncStatusUseCase);
     expect(container.useCases.market.getLatestPrice).toBeInstanceOf(GetLatestPriceUseCase);
     expect(container.useCases.market.calculateZigZag).toBeInstanceOf(CalculateZigZagUseCase);
@@ -38,6 +43,7 @@ describe('createAppContainer', () => {
     expect(Object.isFrozen(container.repositories)).toBe(true);
     expect(Object.isFrozen(container.useCases)).toBe(true);
     expect(Object.isFrozen(container.useCases.community)).toBe(true);
+    expect(Object.isFrozen(container.useCases.researchNotes)).toBe(true);
     expect(Object.isFrozen(container.useCases.sync)).toBe(true);
     expect(Object.isFrozen(container.useCases.market)).toBe(true);
   });

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -1,6 +1,7 @@
 import { CalculateZigZagUseCase } from "../application/use_case/calculateZigZagUseCase";
 import { CreateCommunityReplyUseCase } from "../application/use_case/createCommunityReplyUseCase";
 import { CreateCommunityThreadUseCase } from "../application/use_case/createCommunityThreadUseCase";
+import { CreateResearchNoteUseCase } from "../application/use_case/createResearchNoteUseCase";
 import { GetCommunityThreadDetailUseCase } from "../application/use_case/getCommunityThreadDetailUseCase";
 import { GetCommunityThreadsUseCase } from "../application/use_case/getCommunityThreadsUseCase";
 import { GetLatestPriceUseCase } from "../application/use_case/getLatestPriceUseCase";
@@ -8,6 +9,7 @@ import { GetRecentEventNamesUseCase } from "../application/use_case/getRecentEve
 import { GetRecentSessionsUseCase } from "../application/use_case/getRecentSessionsUseCase";
 import { GetRecentSessionsWithAutoSyncUseCase } from "../application/use_case/getRecentSessionsWithAutoSyncUseCase";
 import { GetReplayDataUseCase } from "../application/use_case/getReplayDataUseCase";
+import { GetResearchNotesUseCase } from "../application/use_case/getResearchNotesUseCase";
 import { GetSyncStatusUseCase } from "../application/use_case/getSyncStatusUseCase";
 import { db, DbType } from "../infrastructure/database/db";
 import { HttpAnalyticsService } from "../infrastructure/external/analyticsServiceImpl";
@@ -15,6 +17,7 @@ import { HttpAnalyticsSyncPull } from "../infrastructure/external/analyticsSyncP
 import { DrizzleBatchRepository } from "../infrastructure/repository/drizzleBatchRepository";
 import { DrizzleCommunityThreadRepository } from "../infrastructure/repository/drizzleCommunityThreadRepository";
 import { DrizzlePriceRepository } from "../infrastructure/repository/drizzlePriceRepository";
+import { DrizzleResearchNoteRepository } from "../infrastructure/repository/drizzleResearchNoteRepository";
 import { DrizzleSessionRepository } from "../infrastructure/repository/drizzleSessionRepository";
 import { DrizzleSyncRepository } from "../infrastructure/repository/drizzleSyncRepository";
 import { DrizzleZigZagRepository } from "../infrastructure/repository/drizzleZigZagRepository";
@@ -33,6 +36,7 @@ export function createAppContainer(
   options: CreateAppContainerOptions = {},
 ) {
   const communityThreadRepo = new DrizzleCommunityThreadRepository(database);
+  const researchNoteRepo = new DrizzleResearchNoteRepository(database);
   const syncRepo = new DrizzleSyncRepository(database);
   const batchRepo = new DrizzleBatchRepository(database);
   const priceRepo = new DrizzlePriceRepository(database);
@@ -56,6 +60,7 @@ export function createAppContainer(
       syncRepo,
       batchRepo,
       communityThreadRepo,
+      researchNoteRepo,
     },
     useCases: {
       community: {
@@ -63,6 +68,10 @@ export function createAppContainer(
         getThreadDetail: new GetCommunityThreadDetailUseCase(communityThreadRepo),
         createThread: new CreateCommunityThreadUseCase(communityThreadRepo),
         createReply: new CreateCommunityReplyUseCase(communityThreadRepo),
+      },
+      researchNotes: {
+        getNotes: new GetResearchNotesUseCase(researchNoteRepo),
+        createNote: new CreateResearchNoteUseCase(researchNoteRepo),
       },
       sync: {
         getStatus: new GetSyncStatusUseCase(syncRepo),
@@ -94,6 +103,7 @@ export type AppContainer = ReturnType<typeof createAppContainer>;
 export function freezeAppContainer(container: AppContainer): AppContainer {
   Object.freeze(container.repositories);
   Object.freeze(container.useCases.community);
+  Object.freeze(container.useCases.researchNotes);
   Object.freeze(container.useCases.sync);
   Object.freeze(container.useCases.market);
   Object.freeze(container.useCases);

--- a/apps/backend/src/app/createApp.ts
+++ b/apps/backend/src/app/createApp.ts
@@ -15,6 +15,7 @@ import { syncBearerAuth } from "../interface/middleware/syncBearerAuth";
 import { Bindings, AppVariables } from "../interface/types";
 import { registerCommunityRoutes } from "../interface/routes/communityRoutes";
 import { registerMarketRoutes } from "../interface/routes/marketRoutes";
+import { registerResearchNoteRoutes } from "../interface/routes/researchNoteRoutes";
 import { registerSyncRoutes } from "../interface/routes/syncRoutes";
 
 const defaultAllowedOrigins = getAllowedOrigins();
@@ -82,6 +83,7 @@ export function createApp(
   registerSyncRoutes(app, container);
   registerMarketRoutes(app, container);
   registerCommunityRoutes(app, container);
+  registerResearchNoteRoutes(app, container);
 
   app.notFound(handleNotFound);
   app.onError(handleAppError);

--- a/apps/backend/src/application/port/researchNoteRepositoryPort.ts
+++ b/apps/backend/src/application/port/researchNoteRepositoryPort.ts
@@ -1,0 +1,17 @@
+import { CreateResearchNoteInput, ResearchNote } from '../../domain/entities/researchNote';
+
+/**
+ * ResearchNoteRepositoryPort はリサーチメモを管理するリポジトリインターフェースです。
+ * @responsibility: メモの作成と一覧取得を永続化層へ委譲する境界を定義する。
+ */
+export interface ResearchNoteRepositoryPort {
+  /**
+   * リサーチメモ一覧を新しい順で取得します。
+   */
+  findAll(limit: number): Promise<ResearchNote[]>;
+
+  /**
+   * 新規リサーチメモを作成して返します。
+   */
+  create(input: CreateResearchNoteInput): Promise<ResearchNote>;
+}

--- a/apps/backend/src/application/use_case/createResearchNoteUseCase.ts
+++ b/apps/backend/src/application/use_case/createResearchNoteUseCase.ts
@@ -1,0 +1,14 @@
+import { ResearchNoteRepositoryPort } from '../port/researchNoteRepositoryPort';
+import { CreateResearchNoteInput, ResearchNote } from '../../domain/entities/researchNote';
+
+/**
+ * CreateResearchNoteUseCase は新規リサーチメモを作成するユースケースです。
+ * @responsibility: バリデーション済みの入力を受け取り、リポジトリを通じてメモを永続化する。
+ */
+export class CreateResearchNoteUseCase {
+  constructor(private readonly repo: ResearchNoteRepositoryPort) {}
+
+  async execute(input: CreateResearchNoteInput): Promise<ResearchNote> {
+    return this.repo.create(input);
+  }
+}

--- a/apps/backend/src/application/use_case/getResearchNotesUseCase.ts
+++ b/apps/backend/src/application/use_case/getResearchNotesUseCase.ts
@@ -1,0 +1,14 @@
+import { ResearchNoteRepositoryPort } from '../port/researchNoteRepositoryPort';
+import { ResearchNote } from '../../domain/entities/researchNote';
+
+/**
+ * GetResearchNotesUseCase は保存済みリサーチメモ一覧を取得するユースケースです。
+ * @responsibility: リポジトリを通じてメモ一覧を新しい順で返す。
+ */
+export class GetResearchNotesUseCase {
+  constructor(private readonly repo: ResearchNoteRepositoryPort) {}
+
+  async execute(limit = 50): Promise<ResearchNote[]> {
+    return this.repo.findAll(limit);
+  }
+}

--- a/apps/backend/src/application/use_case/test/createResearchNoteUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/createResearchNoteUseCase.test.ts
@@ -1,0 +1,59 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { ResearchNoteRepositoryPort } from '../../port/researchNoteRepositoryPort';
+import { CreateResearchNoteUseCase } from '../createResearchNoteUseCase';
+import { CreateResearchNoteInput, ResearchNote } from '../../../domain/entities/researchNote';
+
+const mockCreated: ResearchNote = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt: '2026-04-01T12:00:00.000Z',
+  updatedAt: '2026-04-01T12:00:00.000Z',
+};
+
+const validInput: CreateResearchNoteInput = {
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+};
+
+const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
+  findAll: mock(() => Promise.resolve([])),
+  create: mock(() => Promise.resolve(mockCreated)),
+  ...overrides,
+});
+
+/**
+ * CreateResearchNoteUseCase Unit Tests
+ * @responsibility: リサーチメモ作成のビジネスロジックを検証する。
+ */
+describe('CreateResearchNoteUseCase (Unit Tests)', () => {
+  describe('正常系', () => {
+    it('入力を渡してリポジトリの create を呼び出し、作成されたメモを返すこと', async () => {
+      // ## Arrange ##
+      const createMock = mock(() => Promise.resolve(mockCreated));
+      const mockRepo = createMockRepo({ create: createMock });
+      const useCase = new CreateResearchNoteUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute(validInput);
+
+      // ## Assert ##
+      expect(createMock).toHaveBeenCalledWith(validInput);
+      expect(result.id).toBe(mockCreated.id);
+      expect(result.title).toBe(mockCreated.title);
+    });
+  });
+
+  describe('異常系', () => {
+    it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
+      // ## Arrange ##
+      const mockRepo = createMockRepo({
+        create: mock(() => Promise.reject(new Error('INSERT失敗'))),
+      });
+      const useCase = new CreateResearchNoteUseCase(mockRepo);
+
+      // ## Act & Assert ##
+      await expect(useCase.execute(validInput)).rejects.toThrow('INSERT失敗');
+    });
+  });
+});

--- a/apps/backend/src/application/use_case/test/getResearchNotesUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/getResearchNotesUseCase.test.ts
@@ -1,0 +1,68 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { ResearchNoteRepositoryPort } from '../../port/researchNoteRepositoryPort';
+import { GetResearchNotesUseCase } from '../getResearchNotesUseCase';
+import { ResearchNote } from '../../../domain/entities/researchNote';
+
+const mockNote: ResearchNote = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt: '2026-04-01T12:00:00.000Z',
+  updatedAt: '2026-04-01T12:00:00.000Z',
+};
+
+const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
+  findAll: mock(() => Promise.resolve([mockNote])),
+  create: mock(() => Promise.resolve(mockNote)),
+  ...overrides,
+});
+
+/**
+ * GetResearchNotesUseCase Unit Tests
+ * @responsibility: 保存済みリサーチメモ一覧取得のビジネスロジックを検証する。
+ */
+describe('GetResearchNotesUseCase (Unit Tests)', () => {
+  describe('正常系', () => {
+    it('デフォルト件数でリポジトリの findAll を呼び出し、メモ一覧を返すこと', async () => {
+      // ## Arrange ##
+      const findAllMock = mock(() => Promise.resolve([mockNote]));
+      const mockRepo = createMockRepo({ findAll: findAllMock });
+      const useCase = new GetResearchNotesUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute();
+
+      // ## Assert ##
+      expect(findAllMock).toHaveBeenCalledWith(50);
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe(mockNote.title);
+    });
+
+    it('リポジトリが空配列を返した場合、空の一覧を返すこと', async () => {
+      // ## Arrange ##
+      const mockRepo = createMockRepo({
+        findAll: mock(() => Promise.resolve([])),
+      });
+      const useCase = new GetResearchNotesUseCase(mockRepo);
+
+      // ## Act ##
+      const result = await useCase.execute();
+
+      // ## Assert ##
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('異常系', () => {
+    it('リポジトリがエラーをスローした場合、そのまま伝播すること', async () => {
+      // ## Arrange ##
+      const mockRepo = createMockRepo({
+        findAll: mock(() => Promise.reject(new Error('SELECT失敗'))),
+      });
+      const useCase = new GetResearchNotesUseCase(mockRepo);
+
+      // ## Act & Assert ##
+      await expect(useCase.execute()).rejects.toThrow('SELECT失敗');
+    });
+  });
+});

--- a/apps/backend/src/domain/entities/researchNote.ts
+++ b/apps/backend/src/domain/entities/researchNote.ts
@@ -1,0 +1,36 @@
+import { z } from '@hono/zod-openapi';
+
+/**
+ * ResearchNoteSchema はリサーチメモのドメインスキーマです。
+ * @responsibility: 指標前後の気づきや戦略メモの識別情報・本文・作成日時を保持する。
+ */
+export const ResearchNoteSchema = z.object({
+  id: z.string().uuid().openapi({ example: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890', description: 'メモID' }),
+  title: z.string().min(1).max(200).openapi({ example: 'CPI発表前の観察メモ', description: 'メモタイトル' }),
+  body: z.string().min(1).max(5000).openapi({ example: '発表前はNY序盤の押し目を待つ。', description: 'メモ本文' }),
+  createdAt: z.string().datetime().openapi({ example: '2026-04-01T12:00:00.000Z', description: '作成日時（ISO 8601）' }),
+  updatedAt: z.string().datetime().openapi({ example: '2026-04-01T12:00:00.000Z', description: '更新日時（ISO 8601）' }),
+}).openapi('ResearchNote');
+
+export type ResearchNote = z.infer<typeof ResearchNoteSchema>;
+
+/**
+ * CreateResearchNoteInputSchema はリサーチメモ作成時のバリデーションスキーマです。
+ * @responsibility: タイトル・本文の必須入力と最大文字数を検証する。
+ */
+export const CreateResearchNoteInputSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'タイトルは1文字以上で入力してください')
+    .max(200, 'タイトルは200文字以内で入力してください')
+    .openapi({ example: 'CPI発表前の観察メモ', description: 'メモタイトル' }),
+  body: z
+    .string()
+    .trim()
+    .min(1, '本文は1文字以上で入力してください')
+    .max(5000, '本文は5000文字以内で入力してください')
+    .openapi({ example: '発表前はNY序盤の押し目を待つ。', description: 'メモ本文' }),
+}).openapi('CreateResearchNoteInput');
+
+export type CreateResearchNoteInput = z.infer<typeof CreateResearchNoteInputSchema>;

--- a/apps/backend/src/infrastructure/database/schema.ts
+++ b/apps/backend/src/infrastructure/database/schema.ts
@@ -89,6 +89,20 @@ export const communityReplies = pgTable('community_replies', {
 ]);
 
 // ==========================================
+// Research Notes Tables
+// ==========================================
+
+export const researchNotes = pgTable('research_notes', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (table) => [
+  index('idx_research_notes_created').on(table.createdAt),
+]);
+
+// ==========================================
 // Better Auth Core Tables
 // ==========================================
 

--- a/apps/backend/src/infrastructure/repository/drizzleResearchNoteRepository.ts
+++ b/apps/backend/src/infrastructure/repository/drizzleResearchNoteRepository.ts
@@ -1,0 +1,51 @@
+import { desc } from 'drizzle-orm';
+import { ResearchNoteRepositoryPort } from '../../application/port/researchNoteRepositoryPort';
+import { CreateResearchNoteInput, ResearchNote } from '../../domain/entities/researchNote';
+import { DbType } from '../database/db';
+import { researchNotes } from '../database/schema';
+
+/**
+ * DrizzleResearchNoteRepository は PostgreSQL (Drizzle) を使用したリサーチメモのリポジトリ実装です。
+ * @responsibility: リサーチメモの作成と一覧取得を担当する。
+ */
+export class DrizzleResearchNoteRepository implements ResearchNoteRepositoryPort {
+  constructor(private readonly db: DbType) {}
+
+  private mapNote(row: typeof researchNotes.$inferSelect): ResearchNote {
+    return {
+      id: row.id,
+      title: row.title,
+      body: row.body,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * findAll はリサーチメモを新しい順で取得します。
+   */
+  async findAll(limit: number): Promise<ResearchNote[]> {
+    const rows = await this.db
+      .select()
+      .from(researchNotes)
+      .orderBy(desc(researchNotes.createdAt))
+      .limit(limit);
+
+    return rows.map((row) => this.mapNote(row));
+  }
+
+  /**
+   * create は新規リサーチメモを作成して返します。
+   */
+  async create(input: CreateResearchNoteInput): Promise<ResearchNote> {
+    const [row] = await this.db
+      .insert(researchNotes)
+      .values({
+        title: input.title,
+        body: input.body,
+      })
+      .returning();
+
+    return this.mapNote(row);
+  }
+}

--- a/apps/backend/src/infrastructure/repository/test/drizzleResearchNoteRepository.test.ts
+++ b/apps/backend/src/infrastructure/repository/test/drizzleResearchNoteRepository.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { createMockDrizzle } from '../../../interface/test/testHelpers';
+import { DrizzleResearchNoteRepository } from '../drizzleResearchNoteRepository';
+
+const createdAt = new Date('2026-04-01T12:00:00.000Z');
+const updatedAt = new Date('2026-04-01T12:30:00.000Z');
+
+const mockRow = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt,
+  updatedAt,
+};
+
+/**
+ * DrizzleResearchNoteRepository Unit Tests
+ * @responsibility: Drizzle ORM を通じたリサーチメモの作成・一覧取得を検証する。
+ */
+describe('DrizzleResearchNoteRepository', () => {
+  describe('findAll', () => {
+    it('リサーチメモを新しい順で取得し、ISO文字列へ変換して返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([mockRow]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.findAll(10);
+
+      // ## Assert ##
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+      expect(mockDb.from).toHaveBeenCalledTimes(1);
+      expect(mockDb.orderBy).toHaveBeenCalledTimes(1);
+      expect(mockDb.limit).toHaveBeenCalledWith(10);
+      expect(result).toEqual([
+        {
+          id: mockRow.id,
+          title: mockRow.title,
+          body: mockRow.body,
+          createdAt: createdAt.toISOString(),
+          updatedAt: updatedAt.toISOString(),
+        },
+      ]);
+    });
+
+    it('保存済みメモが存在しない場合、空配列を返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.findAll(10);
+
+      // ## Assert ##
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('create', () => {
+    it('入力値を insert して作成されたメモを返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([mockRow]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.create({
+        title: mockRow.title,
+        body: mockRow.body,
+      });
+
+      // ## Assert ##
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+      expect(mockDb.values).toHaveBeenCalledWith({
+        title: mockRow.title,
+        body: mockRow.body,
+      });
+      expect(mockDb.returning).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe(mockRow.id);
+      expect(result.updatedAt).toBe(updatedAt.toISOString());
+    });
+  });
+});

--- a/apps/backend/src/interface/controller/researchNoteController.ts
+++ b/apps/backend/src/interface/controller/researchNoteController.ts
@@ -1,0 +1,31 @@
+import { Context } from 'hono';
+import { AppContainer } from '../../app/container';
+import { CreateResearchNoteInput } from '../../domain/entities/researchNote';
+import { AppVariables, Bindings } from '../types';
+
+/**
+ * createResearchNoteController はリサーチメモに関するリクエストを処理するハンドラを作成します。
+ * @responsibility リサーチメモの HTTP リクエストとユースケース実行を接続する。
+ */
+export function createResearchNoteController(container: AppContainer) {
+  return {
+    /**
+     * リサーチメモ一覧の取得
+     * @responsibility ユースケースを実行し、保存済みメモ一覧を JSON 形式で返す。
+     */
+    getNotes: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const notes = await container.useCases.researchNotes.getNotes.execute();
+      return c.json({ notes }, 200);
+    },
+
+    /**
+     * リサーチメモの新規作成
+     * @responsibility リクエストボディをバリデーションし、ユースケースを実行して新規メモを返す。
+     */
+    createNote: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const input = (await c.req.valid('json' as never)) as CreateResearchNoteInput;
+      const note = await container.useCases.researchNotes.createNote.execute(input);
+      return c.json(note, 201);
+    },
+  };
+}

--- a/apps/backend/src/interface/controller/test/researchNoteController.test.ts
+++ b/apps/backend/src/interface/controller/test/researchNoteController.test.ts
@@ -1,0 +1,123 @@
+import { expect, describe, it, mock, beforeEach } from 'bun:test';
+import { AppContainer } from '../../../app/container';
+import { ResearchNote } from '../../../domain/entities/researchNote';
+import { createMockContext } from '../../test/testHelpers';
+import { createResearchNoteController } from '../researchNoteController';
+
+interface MockResponse {
+  body: Record<string, unknown> & {
+    notes?: ResearchNote[];
+    id?: string;
+    title?: string;
+  };
+  status: number;
+}
+
+const mockNote: ResearchNote = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt: '2026-04-01T12:00:00.000Z',
+  updatedAt: '2026-04-01T12:00:00.000Z',
+};
+
+/**
+ * ResearchNoteController Unit Tests
+ * @responsibility: リサーチメモの一覧取得・作成APIの正常系・異常系を検証する。
+ */
+describe('ResearchNoteController', () => {
+  let container: AppContainer;
+  let getNotesExecute: ReturnType<typeof mock>;
+  let createNoteExecute: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    getNotesExecute = mock(() => Promise.resolve([mockNote]));
+    createNoteExecute = mock(() => Promise.resolve(mockNote));
+    container = {
+      useCases: {
+        researchNotes: {
+          getNotes: { execute: getNotesExecute },
+          createNote: { execute: createNoteExecute },
+        },
+      },
+    } as unknown as AppContainer;
+  });
+
+  describe('getNotes', () => {
+    it('保存済みメモ一覧を取得して 200 を返すこと', async () => {
+      // ## Arrange ##
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({});
+
+      // ## Act ##
+      const res = (await controller.getNotes(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.notes).toHaveLength(1);
+      expect(res.body.notes?.[0].id).toBe(mockNote.id);
+      expect(getNotesExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('保存済みメモが存在しない場合、空の notes 配列と 200 を返すこと', async () => {
+      // ## Arrange ##
+      getNotesExecute = mock(() => Promise.resolve([]));
+      container.useCases.researchNotes.getNotes.execute = getNotesExecute;
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({});
+
+      // ## Act ##
+      const res = (await controller.getNotes(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.notes).toEqual([]);
+    });
+
+    it('ユースケースがエラーをスローした場合、グローバルエラーハンドラーへ委譲すること', async () => {
+      // ## Arrange ##
+      getNotesExecute = mock(() => Promise.reject(new Error('DB接続エラー')));
+      container.useCases.researchNotes.getNotes.execute = getNotesExecute;
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({});
+
+      // ## Act & Assert ##
+      await expect(controller.getNotes(c)).rejects.toThrow('DB接続エラー');
+    });
+  });
+
+  describe('createNote', () => {
+    it('有効な入力でリサーチメモを作成して 201 を返すこと', async () => {
+      // ## Arrange ##
+      const body = {
+        title: mockNote.title,
+        body: mockNote.body,
+      };
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, {}, body);
+
+      // ## Act ##
+      const res = (await controller.createNote(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe(mockNote.id);
+      expect(res.body.title).toBe(mockNote.title);
+      expect(createNoteExecute).toHaveBeenCalledWith(body);
+    });
+
+    it('ユースケースがエラーをスローした場合、グローバルエラーハンドラーへ委譲すること', async () => {
+      // ## Arrange ##
+      createNoteExecute = mock(() => Promise.reject(new Error('INSERT失敗')));
+      container.useCases.researchNotes.createNote.execute = createNoteExecute;
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, {}, {
+        title: mockNote.title,
+        body: mockNote.body,
+      });
+
+      // ## Act & Assert ##
+      await expect(controller.createNote(c)).rejects.toThrow('INSERT失敗');
+    });
+  });
+});

--- a/apps/backend/src/interface/routes/openapi.ts
+++ b/apps/backend/src/interface/routes/openapi.ts
@@ -11,6 +11,10 @@ import {
   CreateCommunityReplyInputSchema,
   CreateCommunityThreadInputSchema,
 } from "../../domain/entities/communityThread";
+import {
+  CreateResearchNoteInputSchema,
+  ResearchNoteSchema,
+} from "../../domain/entities/researchNote";
 
 /**
  * Health Check ルート
@@ -362,6 +366,62 @@ export const createCommunityReplyRoute = createRoute({
     },
     404: {
       description: "スレッドが見つかりません",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * リサーチメモ一覧ルート
+ */
+export const researchNotesRoute = createRoute({
+  method: "get",
+  path: "/api/v1/research-notes",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            notes: z.array(ResearchNoteSchema),
+          }),
+        },
+      },
+      description: "保存済みリサーチメモ一覧を新しい順で取得します",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * リサーチメモ作成ルート
+ */
+export const createResearchNoteRoute = createRoute({
+  method: "post",
+  path: "/api/v1/research-notes",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateResearchNoteInputSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: ResearchNoteSchema,
+        },
+      },
+      description: "リサーチメモを作成して返します",
+    },
+    400: {
+      description: "バリデーションエラー",
     },
     500: {
       description: "サーバー内部エラー",

--- a/apps/backend/src/interface/routes/researchNoteRoutes.ts
+++ b/apps/backend/src/interface/routes/researchNoteRoutes.ts
@@ -1,0 +1,21 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { AppContainer } from '../../app/container';
+import { createResearchNoteController } from '../controller/researchNoteController';
+import { AppVariables, Bindings } from '../types';
+import {
+  createResearchNoteRoute,
+  researchNotesRoute,
+} from './openapi';
+
+type BackendApp = OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>;
+
+/**
+ * registerResearchNoteRoutes はリサーチメモAPIのルート登録を行います。
+ * @responsibility リサーチメモドメインの route 定義と controller を結びつける。
+ */
+export function registerResearchNoteRoutes(app: BackendApp, container: AppContainer): void {
+  const controller = createResearchNoteController(container);
+
+  app.openapi(researchNotesRoute, controller.getNotes);
+  app.openapi(createResearchNoteRoute, controller.createNote);
+}

--- a/apps/backend/src/interface/routes/test/apiIntegration.test.ts
+++ b/apps/backend/src/interface/routes/test/apiIntegration.test.ts
@@ -77,6 +77,16 @@ describe("API Response Integrity Tests (Integration)", () => {
       expect(body.lastCandleAt).toBeDefined();
       expect(body.syncHealth).toBeDefined();
     });
+
+    it("GET /api/v1/research-notes: 保存済みメモ一覧を取得できること", async () => {
+      // ## Act ##
+      const res = await app.request("/api/v1/research-notes", {}, mockEnv);
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { notes: unknown[] };
+      expect(body.notes).toBeInstanceOf(Array);
+    });
   });
 
   // ==========================================
@@ -110,6 +120,25 @@ describe("API Response Integrity Tests (Integration)", () => {
     it("GET /api/v1/market/replay: eventパラメータが未指定の場合 400 エラーを返すこと", async () => {
       // ## Act ##
       const res = await app.request("/api/v1/market/replay", {}, mockEnv);
+
+      // ## Assert ##
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /api/v1/research-notes: タイトルが空の場合 400 エラーを返すこと", async () => {
+      // ## Act ##
+      const res = await app.request(
+        "/api/v1/research-notes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "",
+            body: "本文です。",
+          }),
+        },
+        mockEnv,
+      );
 
       // ## Assert ##
       expect(res.status).toBe(400);


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #37

# Todo

- [x] リサーチメモのEntity/型を定義
- [x] `research_notes` テーブルとDrizzle migrationを追加
- [x] メモ作成APIを実装
- [x] メモ一覧取得APIを実装
- [x] タイトル・本文のバリデーションを追加
- [x] 正常系・異常系の単体/統合テストを追加

# How to check (動作確認の手順)

```zsh
PATH="/home/somah/.bun/bin:$PATH" bun run lint:all
PATH="/home/somah/.bun/bin:$PATH" bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-10 18:22 (JST)
- ブランチ: features/issue-40-edit-delete-research-notes

```zsh
bun run lint:all
# pass

bun run test:all
# frontend: 118 pass / 0 fail
# backend: 127 pass / 0 fail
```

</details>

# Related Links

- Stacked base: develop
- Follow-up: #38, #39, #40
