### PR TITLE
[FE] リサーチメモフォームを保存APIに接続する

### DIFF
--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -5,6 +5,31 @@
 
 ## 🏗️ 最近の作業ログ (Recent Work Logs)
 
+### 2026-05-10 - Issue #37-#40 リサーチメモ機能スタックPR作成
+
+- **達成したタスク**:
+  - ノートPC同期系を除いた残Issueとして #37 -> #38 -> #39 -> #40 を依存順に実装し、スタックPR #104-#107 を作成。
+  - #37: Backendに `research_notes` テーブル、Drizzle migration `0004_dry_magdalene.sql`、Entity/Port/UseCase/Repository/Controller/OpenAPI routeを追加。
+  - #38: `ResearchNoteForm` を保存API接続へ変更し、成功/失敗Toast、送信中disabled、APIラッパーを追加。
+  - #39: ダッシュボード右カラムに `ResearchNotesPanel` を追加し、保存済みメモ一覧、ローディング、空状態、取得失敗表示を実装。
+  - #40: リサーチメモ更新/削除API、Frontend APIラッパー、編集モーダル、削除確認UI、zodバリデーション、成功/失敗Toastを追加。
+
+- **主要PR/ブランチ**:
+  - #104 `features/issue-37-research-notes-api` base `develop`
+  - #105 `features/issue-38-connect-research-form` base `features/issue-37-research-notes-api`
+  - #106 `features/issue-39-research-notes-list` base `features/issue-38-connect-research-form`
+  - #107 `features/issue-40-edit-delete-research-notes` base `features/issue-39-research-notes-list`
+
+- **検証結果**:
+  - `PATH="/home/somah/.bun/bin:$PATH" bun run lint:all`: pass
+  - `PATH="/home/somah/.bun/bin:$PATH" bun run test:all`: frontend 118 pass / backend 127 pass
+  - GitHub Actions `lint-and-test`: PR #104, #105, #106, #107 すべて pass / mergeState CLEAN
+
+- **次回への申し送り事項**:
+  - マージ順は #107 -> #106 -> #105 -> #104 ではなく、上位差分から下位ブランチへ取り込むスタック運用に合わせて、まず #107 を #106 へ、#106 を #105 へ、#105 を #104 へ、最後に #104 を `develop` へ反映する。
+  - PRマージ後、baseが `develop` ではないPRの `Closes` が自動クローズされない場合は #37-#40 を手動で完了コメント付きクローズする。
+  - 残Open IssueはノートPC同期運用系 #76-#78 のみになる想定。
+
 ### 2026-05-09 - Issue/PR最新同期と次Issue依存整理
 
 - **達成したタスク**:

--- a/.agents/PROJECT_MEMORY.md
+++ b/.agents/PROJECT_MEMORY.md
@@ -30,6 +30,31 @@
   - PRマージ後、baseが `develop` ではないPRの `Closes` が自動クローズされない場合は #37-#40 を手動で完了コメント付きクローズする。
   - 残Open IssueはノートPC同期運用系 #76-#78 のみになる想定。
 
+### 2026-05-09 - Issue #32-#36 スタックPR作成・CI修正・レビューコメント対応
+
+- **達成したタスク**:
+  - ノートPC同期系以外のIssueとして #32 -> #33 -> #34 -> #35 -> #36 を依存順に実装し、スタックPR #98-#102 を作成。
+  - #98 のCI失敗を確認し、`CommunityThreadDetail` の返信作成APIを依存注入できるようにしてテスト安定化。
+  - `.github/workflows/ci.yml` の `pull_request.branches` 制限を外し、`develop` 以外をbaseにするスタックPRでもCIが走るように修正。
+  - PR #98-#102 のGeminiレビューコメントを確認し、JSDoc `@responsibility` 追加、`Intl.DateTimeFormat` のhoist、記事データコピー返却、表示日付/OG localeテスト、`NEXT_PUBLIC_SITE_URL` 末尾スラッシュ除去などを対応。
+  - #101 で追加した `copyInsightPost` helper にも `@responsibility` 付きJSDocを補い、#102へ再マージ済み。
+
+- **主要PR/ブランチ**:
+  - #98 `feature/issue-32-community-thread-detail` base `develop`
+  - #99 `feature/issue-33-insights-content-source` base `feature/issue-32-community-thread-detail`
+  - #100 `feature/issue-34-insights-list-data` base `feature/issue-33-insights-content-source`
+  - #101 `feature/issue-35-insights-detail-page` base `feature/issue-34-insights-list-data`
+  - #102 `feature/issue-36-insights-seo-sitemap` base `feature/issue-35-insights-detail-page`
+
+- **検証結果**:
+  - `bun run lint:all`: pass
+  - `bun run test:all`: frontend 96 pass / backend 100 pass
+  - GitHub Actions `lint-and-test`: PR #98, #99, #100, #101, #102 すべて pass
+
+- **次回への申し送り事項**:
+  - GitHub上のレビューThreadはコード対応済みだが、明示的なresolve/reply操作は未実施。必要なら各PRコメントへ対応内容を返信し、Threadをresolvedにする。
+  - 次に進むなら #37 リサーチメモ保存APIを #36 の後続として積むか、スタックPRを順にマージしてから着手する。
+
 ### 2026-05-09 - Issue/PR最新同期と次Issue依存整理
 
 - **達成したタスク**:

--- a/apps/backend/src/app/container.test.ts
+++ b/apps/backend/src/app/container.test.ts
@@ -3,6 +3,7 @@ import { CalculateZigZagUseCase } from '../application/use_case/calculateZigZagU
 import { CreateCommunityReplyUseCase } from '../application/use_case/createCommunityReplyUseCase';
 import { CreateCommunityThreadUseCase } from '../application/use_case/createCommunityThreadUseCase';
 import { CreateResearchNoteUseCase } from '../application/use_case/createResearchNoteUseCase';
+import { DeleteResearchNoteUseCase } from '../application/use_case/deleteResearchNoteUseCase';
 import { GetCommunityThreadDetailUseCase } from '../application/use_case/getCommunityThreadDetailUseCase';
 import { GetCommunityThreadsUseCase } from '../application/use_case/getCommunityThreadsUseCase';
 import { GetLatestPriceUseCase } from '../application/use_case/getLatestPriceUseCase';
@@ -11,6 +12,7 @@ import { GetRecentSessionsWithAutoSyncUseCase } from '../application/use_case/ge
 import { GetReplayDataUseCase } from '../application/use_case/getReplayDataUseCase';
 import { GetResearchNotesUseCase } from '../application/use_case/getResearchNotesUseCase';
 import { GetSyncStatusUseCase } from '../application/use_case/getSyncStatusUseCase';
+import { UpdateResearchNoteUseCase } from '../application/use_case/updateResearchNoteUseCase';
 import { createAppContainer, freezeAppContainer } from './container';
 import { createMockDrizzle } from '../interface/test/testHelpers';
 
@@ -28,6 +30,8 @@ describe('createAppContainer', () => {
     expect(container.useCases.community.createReply).toBeInstanceOf(CreateCommunityReplyUseCase);
     expect(container.useCases.researchNotes.getNotes).toBeInstanceOf(GetResearchNotesUseCase);
     expect(container.useCases.researchNotes.createNote).toBeInstanceOf(CreateResearchNoteUseCase);
+    expect(container.useCases.researchNotes.updateNote).toBeInstanceOf(UpdateResearchNoteUseCase);
+    expect(container.useCases.researchNotes.deleteNote).toBeInstanceOf(DeleteResearchNoteUseCase);
     expect(container.useCases.sync.getStatus).toBeInstanceOf(GetSyncStatusUseCase);
     expect(container.useCases.market.getLatestPrice).toBeInstanceOf(GetLatestPriceUseCase);
     expect(container.useCases.market.calculateZigZag).toBeInstanceOf(CalculateZigZagUseCase);

--- a/apps/backend/src/app/container.ts
+++ b/apps/backend/src/app/container.ts
@@ -2,6 +2,7 @@ import { CalculateZigZagUseCase } from "../application/use_case/calculateZigZagU
 import { CreateCommunityReplyUseCase } from "../application/use_case/createCommunityReplyUseCase";
 import { CreateCommunityThreadUseCase } from "../application/use_case/createCommunityThreadUseCase";
 import { CreateResearchNoteUseCase } from "../application/use_case/createResearchNoteUseCase";
+import { DeleteResearchNoteUseCase } from "../application/use_case/deleteResearchNoteUseCase";
 import { GetCommunityThreadDetailUseCase } from "../application/use_case/getCommunityThreadDetailUseCase";
 import { GetCommunityThreadsUseCase } from "../application/use_case/getCommunityThreadsUseCase";
 import { GetLatestPriceUseCase } from "../application/use_case/getLatestPriceUseCase";
@@ -11,6 +12,7 @@ import { GetRecentSessionsWithAutoSyncUseCase } from "../application/use_case/ge
 import { GetReplayDataUseCase } from "../application/use_case/getReplayDataUseCase";
 import { GetResearchNotesUseCase } from "../application/use_case/getResearchNotesUseCase";
 import { GetSyncStatusUseCase } from "../application/use_case/getSyncStatusUseCase";
+import { UpdateResearchNoteUseCase } from "../application/use_case/updateResearchNoteUseCase";
 import { db, DbType } from "../infrastructure/database/db";
 import { HttpAnalyticsService } from "../infrastructure/external/analyticsServiceImpl";
 import { HttpAnalyticsSyncPull } from "../infrastructure/external/analyticsSyncPullImpl";
@@ -72,6 +74,8 @@ export function createAppContainer(
       researchNotes: {
         getNotes: new GetResearchNotesUseCase(researchNoteRepo),
         createNote: new CreateResearchNoteUseCase(researchNoteRepo),
+        updateNote: new UpdateResearchNoteUseCase(researchNoteRepo),
+        deleteNote: new DeleteResearchNoteUseCase(researchNoteRepo),
       },
       sync: {
         getStatus: new GetSyncStatusUseCase(syncRepo),

--- a/apps/backend/src/application/port/researchNoteRepositoryPort.ts
+++ b/apps/backend/src/application/port/researchNoteRepositoryPort.ts
@@ -1,4 +1,8 @@
-import { CreateResearchNoteInput, ResearchNote } from '../../domain/entities/researchNote';
+import {
+  CreateResearchNoteInput,
+  ResearchNote,
+  UpdateResearchNoteInput,
+} from '../../domain/entities/researchNote';
 
 /**
  * ResearchNoteRepositoryPort はリサーチメモを管理するリポジトリインターフェースです。
@@ -14,4 +18,14 @@ export interface ResearchNoteRepositoryPort {
    * 新規リサーチメモを作成して返します。
    */
   create(input: CreateResearchNoteInput): Promise<ResearchNote>;
+
+  /**
+   * 既存リサーチメモを更新して返します。
+   */
+  update(noteId: string, input: UpdateResearchNoteInput): Promise<ResearchNote | null>;
+
+  /**
+   * 既存リサーチメモを削除します。
+   */
+  delete(noteId: string): Promise<boolean>;
 }

--- a/apps/backend/src/application/use_case/deleteResearchNoteUseCase.ts
+++ b/apps/backend/src/application/use_case/deleteResearchNoteUseCase.ts
@@ -1,0 +1,13 @@
+import { ResearchNoteRepositoryPort } from '../port/researchNoteRepositoryPort';
+
+/**
+ * DeleteResearchNoteUseCase は保存済みリサーチメモを削除するユースケースです。
+ * @responsibility: 対象IDのメモ削除をリポジトリへ委譲し、削除成否を返す。
+ */
+export class DeleteResearchNoteUseCase {
+  constructor(private readonly repo: ResearchNoteRepositoryPort) {}
+
+  async execute(noteId: string): Promise<boolean> {
+    return this.repo.delete(noteId);
+  }
+}

--- a/apps/backend/src/application/use_case/test/createResearchNoteUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/createResearchNoteUseCase.test.ts
@@ -19,6 +19,8 @@ const validInput: CreateResearchNoteInput = {
 const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
   findAll: mock(() => Promise.resolve([])),
   create: mock(() => Promise.resolve(mockCreated)),
+  update: mock(() => Promise.resolve(mockCreated)),
+  delete: mock(() => Promise.resolve(true)),
   ...overrides,
 });
 

--- a/apps/backend/src/application/use_case/test/deleteResearchNoteUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/deleteResearchNoteUseCase.test.ts
@@ -1,0 +1,50 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { ResearchNoteRepositoryPort } from '../../port/researchNoteRepositoryPort';
+import { ResearchNote } from '../../../domain/entities/researchNote';
+import { DeleteResearchNoteUseCase } from '../deleteResearchNoteUseCase';
+
+const mockNote: ResearchNote = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt: '2026-04-01T12:00:00.000Z',
+  updatedAt: '2026-04-01T12:00:00.000Z',
+};
+
+const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
+  findAll: mock(() => Promise.resolve([])),
+  create: mock(() => Promise.resolve(mockNote)),
+  update: mock(() => Promise.resolve(mockNote)),
+  delete: mock(() => Promise.resolve(true)),
+  ...overrides,
+});
+
+describe('DeleteResearchNoteUseCase (Unit Tests)', () => {
+  it('入力IDを渡してリポジトリの delete を呼び出し、削除成功を返すこと', async () => {
+    // ## Arrange ##
+    const deleteMock = mock(() => Promise.resolve(true));
+    const mockRepo = createMockRepo({ delete: deleteMock });
+    const useCase = new DeleteResearchNoteUseCase(mockRepo);
+
+    // ## Act ##
+    const result = await useCase.execute(mockNote.id);
+
+    // ## Assert ##
+    expect(deleteMock).toHaveBeenCalledWith(mockNote.id);
+    expect(result).toBe(true);
+  });
+
+  it('対象メモが存在しない場合、false を返すこと', async () => {
+    // ## Arrange ##
+    const mockRepo = createMockRepo({
+      delete: mock(() => Promise.resolve(false)),
+    });
+    const useCase = new DeleteResearchNoteUseCase(mockRepo);
+
+    // ## Act ##
+    const result = await useCase.execute(mockNote.id);
+
+    // ## Assert ##
+    expect(result).toBe(false);
+  });
+});

--- a/apps/backend/src/application/use_case/test/getResearchNotesUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/getResearchNotesUseCase.test.ts
@@ -14,6 +14,8 @@ const mockNote: ResearchNote = {
 const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
   findAll: mock(() => Promise.resolve([mockNote])),
   create: mock(() => Promise.resolve(mockNote)),
+  update: mock(() => Promise.resolve(mockNote)),
+  delete: mock(() => Promise.resolve(true)),
   ...overrides,
 });
 

--- a/apps/backend/src/application/use_case/test/updateResearchNoteUseCase.test.ts
+++ b/apps/backend/src/application/use_case/test/updateResearchNoteUseCase.test.ts
@@ -1,0 +1,55 @@
+import { expect, describe, it, mock } from 'bun:test';
+import { ResearchNoteRepositoryPort } from '../../port/researchNoteRepositoryPort';
+import { ResearchNote, UpdateResearchNoteInput } from '../../../domain/entities/researchNote';
+import { UpdateResearchNoteUseCase } from '../updateResearchNoteUseCase';
+
+const mockNote: ResearchNote = {
+  id: 'c1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'CPI発表前の観察メモ',
+  body: '発表前はNY序盤の押し目を待つ。',
+  createdAt: '2026-04-01T12:00:00.000Z',
+  updatedAt: '2026-04-01T12:30:00.000Z',
+};
+
+const validInput: UpdateResearchNoteInput = {
+  title: 'CPI発表後の観察メモ',
+  body: '初動とNY後半の戻りを比較する。',
+};
+
+const createMockRepo = (overrides: Partial<ResearchNoteRepositoryPort> = {}): ResearchNoteRepositoryPort => ({
+  findAll: mock(() => Promise.resolve([])),
+  create: mock(() => Promise.resolve(mockNote)),
+  update: mock(() => Promise.resolve(mockNote)),
+  delete: mock(() => Promise.resolve(true)),
+  ...overrides,
+});
+
+describe('UpdateResearchNoteUseCase (Unit Tests)', () => {
+  it('入力を渡してリポジトリの update を呼び出し、更新されたメモを返すこと', async () => {
+    // ## Arrange ##
+    const updateMock = mock(() => Promise.resolve(mockNote));
+    const mockRepo = createMockRepo({ update: updateMock });
+    const useCase = new UpdateResearchNoteUseCase(mockRepo);
+
+    // ## Act ##
+    const result = await useCase.execute(mockNote.id, validInput);
+
+    // ## Assert ##
+    expect(updateMock).toHaveBeenCalledWith(mockNote.id, validInput);
+    expect(result?.id).toBe(mockNote.id);
+  });
+
+  it('対象メモが存在しない場合、null を返すこと', async () => {
+    // ## Arrange ##
+    const mockRepo = createMockRepo({
+      update: mock(() => Promise.resolve(null)),
+    });
+    const useCase = new UpdateResearchNoteUseCase(mockRepo);
+
+    // ## Act ##
+    const result = await useCase.execute(mockNote.id, validInput);
+
+    // ## Assert ##
+    expect(result).toBeNull();
+  });
+});

--- a/apps/backend/src/application/use_case/updateResearchNoteUseCase.ts
+++ b/apps/backend/src/application/use_case/updateResearchNoteUseCase.ts
@@ -1,0 +1,14 @@
+import { ResearchNoteRepositoryPort } from '../port/researchNoteRepositoryPort';
+import { ResearchNote, UpdateResearchNoteInput } from '../../domain/entities/researchNote';
+
+/**
+ * UpdateResearchNoteUseCase は保存済みリサーチメモを更新するユースケースです。
+ * @responsibility: バリデーション済みの入力を受け取り、対象メモの内容を更新する。
+ */
+export class UpdateResearchNoteUseCase {
+  constructor(private readonly repo: ResearchNoteRepositoryPort) {}
+
+  async execute(noteId: string, input: UpdateResearchNoteInput): Promise<ResearchNote | null> {
+    return this.repo.update(noteId, input);
+  }
+}

--- a/apps/backend/src/domain/entities/researchNote.ts
+++ b/apps/backend/src/domain/entities/researchNote.ts
@@ -34,3 +34,11 @@ export const CreateResearchNoteInputSchema = z.object({
 }).openapi('CreateResearchNoteInput');
 
 export type CreateResearchNoteInput = z.infer<typeof CreateResearchNoteInputSchema>;
+
+/**
+ * UpdateResearchNoteInputSchema はリサーチメモ更新時のバリデーションスキーマです。
+ * @responsibility: 編集フォームから送られるタイトル・本文の必須入力と最大文字数を検証する。
+ */
+export const UpdateResearchNoteInputSchema = CreateResearchNoteInputSchema.openapi('UpdateResearchNoteInput');
+
+export type UpdateResearchNoteInput = z.infer<typeof UpdateResearchNoteInputSchema>;

--- a/apps/backend/src/infrastructure/repository/drizzleResearchNoteRepository.ts
+++ b/apps/backend/src/infrastructure/repository/drizzleResearchNoteRepository.ts
@@ -1,8 +1,13 @@
 import { desc } from 'drizzle-orm';
 import { ResearchNoteRepositoryPort } from '../../application/port/researchNoteRepositoryPort';
-import { CreateResearchNoteInput, ResearchNote } from '../../domain/entities/researchNote';
+import {
+  CreateResearchNoteInput,
+  ResearchNote,
+  UpdateResearchNoteInput,
+} from '../../domain/entities/researchNote';
 import { DbType } from '../database/db';
 import { researchNotes } from '../database/schema';
+import { eq } from 'drizzle-orm';
 
 /**
  * DrizzleResearchNoteRepository は PostgreSQL (Drizzle) を使用したリサーチメモのリポジトリ実装です。
@@ -47,5 +52,34 @@ export class DrizzleResearchNoteRepository implements ResearchNoteRepositoryPort
       .returning();
 
     return this.mapNote(row);
+  }
+
+  /**
+   * update は既存リサーチメモを更新して返します。
+   */
+  async update(noteId: string, input: UpdateResearchNoteInput): Promise<ResearchNote | null> {
+    const [row] = await this.db
+      .update(researchNotes)
+      .set({
+        title: input.title,
+        body: input.body,
+        updatedAt: new Date(),
+      })
+      .where(eq(researchNotes.id, noteId))
+      .returning();
+
+    return row ? this.mapNote(row) : null;
+  }
+
+  /**
+   * delete は既存リサーチメモを削除します。
+   */
+  async delete(noteId: string): Promise<boolean> {
+    const rows = await this.db
+      .delete(researchNotes)
+      .where(eq(researchNotes.id, noteId))
+      .returning({ id: researchNotes.id });
+
+    return rows.length > 0;
   }
 }

--- a/apps/backend/src/infrastructure/repository/test/drizzleResearchNoteRepository.test.ts
+++ b/apps/backend/src/infrastructure/repository/test/drizzleResearchNoteRepository.test.ts
@@ -79,4 +79,70 @@ describe('DrizzleResearchNoteRepository', () => {
       expect(result.updatedAt).toBe(updatedAt.toISOString());
     });
   });
+
+  describe('update', () => {
+    it('入力値で既存メモを更新し、更新されたメモを返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([mockRow]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.update(mockRow.id, {
+        title: 'CPI発表後の観察メモ',
+        body: '初動とNY後半の戻りを比較する。',
+      });
+
+      // ## Assert ##
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'CPI発表後の観察メモ',
+        body: '初動とNY後半の戻りを比較する。',
+      }));
+      expect(mockDb.where).toHaveBeenCalledTimes(1);
+      expect(result?.id).toBe(mockRow.id);
+    });
+
+    it('対象メモが存在しない場合、null を返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.update(mockRow.id, {
+        title: 'CPI発表後の観察メモ',
+        body: '初動とNY後半の戻りを比較する。',
+      });
+
+      // ## Assert ##
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('対象メモを削除し、削除成功を返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([{ id: mockRow.id }]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.delete(mockRow.id);
+
+      // ## Assert ##
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+      expect(mockDb.where).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+    });
+
+    it('対象メモが存在しない場合、false を返すこと', async () => {
+      // ## Arrange ##
+      const mockDb = createMockDrizzle([]);
+      const repo = new DrizzleResearchNoteRepository(mockDb);
+
+      // ## Act ##
+      const result = await repo.delete(mockRow.id);
+
+      // ## Assert ##
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/apps/backend/src/interface/controller/researchNoteController.ts
+++ b/apps/backend/src/interface/controller/researchNoteController.ts
@@ -1,6 +1,9 @@
 import { Context } from 'hono';
 import { AppContainer } from '../../app/container';
-import { CreateResearchNoteInput } from '../../domain/entities/researchNote';
+import {
+  CreateResearchNoteInput,
+  UpdateResearchNoteInput,
+} from '../../domain/entities/researchNote';
 import { AppVariables, Bindings } from '../types';
 
 /**
@@ -26,6 +29,37 @@ export function createResearchNoteController(container: AppContainer) {
       const input = (await c.req.valid('json' as never)) as CreateResearchNoteInput;
       const note = await container.useCases.researchNotes.createNote.execute(input);
       return c.json(note, 201);
+    },
+
+    /**
+     * リサーチメモの更新
+     * @responsibility URLパラメータとボディを受け取り、対象メモを更新する。
+     */
+    updateNote: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const { noteId } = (await c.req.valid('param' as never)) as { noteId: string };
+      const input = (await c.req.valid('json' as never)) as UpdateResearchNoteInput;
+      const note = await container.useCases.researchNotes.updateNote.execute(noteId, input);
+
+      if (!note) {
+        return c.json({ message: 'リサーチメモが見つかりません' }, 404);
+      }
+
+      return c.json(note, 200);
+    },
+
+    /**
+     * リサーチメモの削除
+     * @responsibility URLパラメータを受け取り、対象メモを削除する。
+     */
+    deleteNote: async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => {
+      const { noteId } = (await c.req.valid('param' as never)) as { noteId: string };
+      const deleted = await container.useCases.researchNotes.deleteNote.execute(noteId);
+
+      if (!deleted) {
+        return c.json({ message: 'リサーチメモが見つかりません' }, 404);
+      }
+
+      return c.json({ success: true }, 200);
     },
   };
 }

--- a/apps/backend/src/interface/controller/test/researchNoteController.test.ts
+++ b/apps/backend/src/interface/controller/test/researchNoteController.test.ts
@@ -9,6 +9,7 @@ interface MockResponse {
     notes?: ResearchNote[];
     id?: string;
     title?: string;
+    success?: boolean;
   };
   status: number;
 }
@@ -29,15 +30,21 @@ describe('ResearchNoteController', () => {
   let container: AppContainer;
   let getNotesExecute: ReturnType<typeof mock>;
   let createNoteExecute: ReturnType<typeof mock>;
+  let updateNoteExecute: ReturnType<typeof mock>;
+  let deleteNoteExecute: ReturnType<typeof mock>;
 
   beforeEach(() => {
     getNotesExecute = mock(() => Promise.resolve([mockNote]));
     createNoteExecute = mock(() => Promise.resolve(mockNote));
+    updateNoteExecute = mock(() => Promise.resolve(mockNote));
+    deleteNoteExecute = mock(() => Promise.resolve(true));
     container = {
       useCases: {
         researchNotes: {
           getNotes: { execute: getNotesExecute },
           createNote: { execute: createNoteExecute },
+          updateNote: { execute: updateNoteExecute },
+          deleteNote: { execute: deleteNoteExecute },
         },
       },
     } as unknown as AppContainer;
@@ -118,6 +125,73 @@ describe('ResearchNoteController', () => {
 
       // ## Act & Assert ##
       await expect(controller.createNote(c)).rejects.toThrow('INSERT失敗');
+    });
+  });
+
+  describe('updateNote', () => {
+    it('有効な入力でリサーチメモを更新して 200 を返すこと', async () => {
+      // ## Arrange ##
+      const body = {
+        title: 'CPI発表後の観察メモ',
+        body: '初動とNY後半の戻りを比較する。',
+      };
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, { noteId: mockNote.id }, body);
+
+      // ## Act ##
+      const res = (await controller.updateNote(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(mockNote.id);
+      expect(updateNoteExecute).toHaveBeenCalledWith(mockNote.id, body);
+    });
+
+    it('対象メモが存在しない場合 404 を返すこと', async () => {
+      // ## Arrange ##
+      updateNoteExecute = mock(() => Promise.resolve(null));
+      container.useCases.researchNotes.updateNote.execute = updateNoteExecute;
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, { noteId: mockNote.id }, {
+        title: mockNote.title,
+        body: mockNote.body,
+      });
+
+      // ## Act ##
+      const res = (await controller.updateNote(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('deleteNote', () => {
+    it('対象メモを削除して 200 を返すこと', async () => {
+      // ## Arrange ##
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, { noteId: mockNote.id });
+
+      // ## Act ##
+      const res = (await controller.deleteNote(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(deleteNoteExecute).toHaveBeenCalledWith(mockNote.id);
+    });
+
+    it('対象メモが存在しない場合 404 を返すこと', async () => {
+      // ## Arrange ##
+      deleteNoteExecute = mock(() => Promise.resolve(false));
+      container.useCases.researchNotes.deleteNote.execute = deleteNoteExecute;
+      const controller = createResearchNoteController(container);
+      const c = createMockContext({}, {}, { noteId: mockNote.id });
+
+      // ## Act ##
+      const res = (await controller.deleteNote(c)) as unknown as MockResponse;
+
+      // ## Assert ##
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/apps/backend/src/interface/routes/openapi.ts
+++ b/apps/backend/src/interface/routes/openapi.ts
@@ -14,6 +14,7 @@ import {
 import {
   CreateResearchNoteInputSchema,
   ResearchNoteSchema,
+  UpdateResearchNoteInputSchema,
 } from "../../domain/entities/researchNote";
 
 /**
@@ -422,6 +423,82 @@ export const createResearchNoteRoute = createRoute({
     },
     400: {
       description: "バリデーションエラー",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * リサーチメモ更新ルート
+ */
+export const updateResearchNoteRoute = createRoute({
+  method: "patch",
+  path: "/api/v1/research-notes/{noteId}",
+  request: {
+    params: z.object({
+      noteId: z.string().uuid().openapi({
+        param: { name: "noteId", in: "path" },
+        example: "c1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        description: "メモID",
+      }),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: UpdateResearchNoteInputSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ResearchNoteSchema,
+        },
+      },
+      description: "リサーチメモを更新して返します",
+    },
+    400: {
+      description: "バリデーションエラー",
+    },
+    404: {
+      description: "リサーチメモが見つかりません",
+    },
+    500: {
+      description: "サーバー内部エラー",
+    },
+  },
+});
+
+/**
+ * リサーチメモ削除ルート
+ */
+export const deleteResearchNoteRoute = createRoute({
+  method: "delete",
+  path: "/api/v1/research-notes/{noteId}",
+  request: {
+    params: z.object({
+      noteId: z.string().uuid().openapi({
+        param: { name: "noteId", in: "path" },
+        example: "c1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        description: "メモID",
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ success: z.boolean() }),
+        },
+      },
+      description: "リサーチメモを削除します",
+    },
+    404: {
+      description: "リサーチメモが見つかりません",
     },
     500: {
       description: "サーバー内部エラー",

--- a/apps/backend/src/interface/routes/researchNoteRoutes.ts
+++ b/apps/backend/src/interface/routes/researchNoteRoutes.ts
@@ -3,8 +3,10 @@ import { AppContainer } from '../../app/container';
 import { createResearchNoteController } from '../controller/researchNoteController';
 import { AppVariables, Bindings } from '../types';
 import {
+  deleteResearchNoteRoute,
   createResearchNoteRoute,
   researchNotesRoute,
+  updateResearchNoteRoute,
 } from './openapi';
 
 type BackendApp = OpenAPIHono<{ Bindings: Bindings; Variables: AppVariables }>;
@@ -18,4 +20,6 @@ export function registerResearchNoteRoutes(app: BackendApp, container: AppContai
 
   app.openapi(researchNotesRoute, controller.getNotes);
   app.openapi(createResearchNoteRoute, controller.createNote);
+  app.openapi(updateResearchNoteRoute, controller.updateNote);
+  app.openapi(deleteResearchNoteRoute, controller.deleteNote);
 }

--- a/apps/backend/src/interface/test/testHelpers.ts
+++ b/apps/backend/src/interface/test/testHelpers.ts
@@ -12,6 +12,7 @@ type MockQueryBuilder = {
   groupBy: ReturnType<typeof mock>;
   insert: ReturnType<typeof mock>;
   update: ReturnType<typeof mock>;
+  delete: ReturnType<typeof mock>;
   values: ReturnType<typeof mock>;
   set: ReturnType<typeof mock>;
   returning: ReturnType<typeof mock>;
@@ -35,6 +36,7 @@ export const createMockDrizzle = <T = unknown>(results: T[] = []) => {
     groupBy: mock(() => queryMock),
     insert: mock(() => queryMock),
     update: mock(() => queryMock),
+    delete: mock(() => queryMock),
     values: mock(() => queryMock),
     set: mock(() => queryMock),
     returning: mock(() => queryMock),

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import ReplaySkeleton from '@/features/market-replay/components/ReplaySkeleton';
 import { SessionFactTimeline } from '@/features/sessions/components/SessionFactTimeline';
 import { getIndicators } from '@/features/common/api/getIndicators';
 import { LiveStatusBadge } from '@/features/sessions/components/LiveStatusBadge';
-import { ResearchNoteForm } from '@/features/forms/components/ResearchNoteForm';
+import { ResearchNotesPanel } from '@/features/forms/components/ResearchNotesPanel';
 
 const valueHighlights = [
   {
@@ -172,7 +172,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
                     <SessionFactTimeline />
                   </Suspense>
                 </div>
-                <ResearchNoteForm />
+                <ResearchNotesPanel />
               </div>
             </aside>
           </div>

--- a/apps/frontend/src/features/forms/api/createResearchNote.test.ts
+++ b/apps/frontend/src/features/forms/api/createResearchNote.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AppClient } from "@/lib/api/client";
+import { createResearchNote } from "./createResearchNote";
+
+const postMock = mock();
+
+const createMockClient = (): AppClient => ({
+  api: {
+    v1: {
+      "research-notes": {
+        $get: mock(),
+        $post: postMock,
+      },
+    },
+  },
+} as unknown as AppClient);
+
+describe("createResearchNote", () => {
+  beforeEach(() => {
+    postMock.mockClear();
+  });
+
+  it("APIが成功した場合、作成済みリサーチメモを返すこと", async () => {
+    // ## Arrange ##
+    const note = {
+      id: "note-new",
+      title: "CPI前後の値動き",
+      body: "発表直後とNY後半の戻りを比較する",
+      createdAt: "2026-05-05T10:00:00Z",
+      updatedAt: "2026-05-05T10:00:00Z",
+    };
+    postMock.mockResolvedValue({
+      ok: true,
+      json: async () => note,
+    });
+
+    // ## Act ##
+    const result = await createResearchNote({
+      title: "CPI前後の値動き",
+      body: "発表直後とNY後半の戻りを比較する",
+    }, createMockClient());
+
+    // ## Assert ##
+    expect(result).toEqual(note);
+    expect(postMock).toHaveBeenCalledWith(
+      {
+        json: {
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+        },
+      },
+      expect.objectContaining({
+        init: expect.objectContaining({
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("APIが失敗した場合、保存エラーを投げること", async () => {
+    // ## Arrange ##
+    postMock.mockResolvedValue({
+      ok: false,
+    });
+
+    // ## Act & Assert ##
+    await expect(createResearchNote({
+      title: "CPI前後の値動き",
+      body: "発表直後とNY後半の戻りを比較する",
+    }, createMockClient())).rejects.toThrow("リサーチメモの保存に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/forms/api/createResearchNote.ts
+++ b/apps/frontend/src/features/forms/api/createResearchNote.ts
@@ -1,0 +1,28 @@
+import { apiClient, type AppClient, type CreateResearchNoteInput } from "@/lib/api/client";
+
+/**
+ * createResearchNote はリサーチメモを新規作成します。
+ * @responsibility メモ保存APIの通信結果を検証し、作成済みメモを返す。
+ */
+export async function createResearchNote(
+  input: CreateResearchNoteInput,
+  client: AppClient = apiClient,
+) {
+  const res = await client.api.v1["research-notes"].$post(
+    { json: input },
+    {
+      init: {
+        headers: {
+          "content-type": "application/json",
+        },
+        signal: AbortSignal.timeout(5000),
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error("リサーチメモの保存に失敗しました");
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/forms/api/deleteResearchNote.test.ts
+++ b/apps/frontend/src/features/forms/api/deleteResearchNote.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AppClient } from "@/lib/api/client";
+import { deleteResearchNote } from "./deleteResearchNote";
+
+const deleteMock = mock();
+
+const createMockClient = (): AppClient => ({
+  api: {
+    v1: {
+      "research-notes": {
+        $get: mock(),
+        $post: mock(),
+        ":noteId": {
+          $patch: mock(),
+          $delete: deleteMock,
+        },
+      },
+    },
+  },
+} as unknown as AppClient);
+
+describe("deleteResearchNote", () => {
+  beforeEach(() => {
+    deleteMock.mockClear();
+  });
+
+  it("APIが成功した場合、削除結果を返すこと", async () => {
+    // ## Arrange ##
+    deleteMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    // ## Act ##
+    const result = await deleteResearchNote("note-1", createMockClient());
+
+    // ## Assert ##
+    expect(result).toEqual({ success: true });
+    expect(deleteMock).toHaveBeenCalledWith(
+      {
+        param: { noteId: "note-1" },
+      },
+      expect.objectContaining({
+        init: expect.any(Object),
+      }),
+    );
+  });
+
+  it("APIが失敗した場合、削除エラーを投げること", async () => {
+    // ## Arrange ##
+    deleteMock.mockResolvedValue({
+      ok: false,
+    });
+
+    // ## Act & Assert ##
+    await expect(deleteResearchNote("note-1", createMockClient())).rejects.toThrow("リサーチメモの削除に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/forms/api/deleteResearchNote.ts
+++ b/apps/frontend/src/features/forms/api/deleteResearchNote.ts
@@ -1,0 +1,27 @@
+import { apiClient, type AppClient } from "@/lib/api/client";
+
+/**
+ * deleteResearchNote は保存済みリサーチメモを削除します。
+ * @responsibility メモ削除APIの通信結果を検証し、削除成否を返す。
+ */
+export async function deleteResearchNote(
+  noteId: string,
+  client: AppClient = apiClient,
+) {
+  const res = await client.api.v1["research-notes"][":noteId"].$delete(
+    {
+      param: { noteId },
+    },
+    {
+      init: {
+        signal: AbortSignal.timeout(5000),
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error("リサーチメモの削除に失敗しました");
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/forms/api/getResearchNotes.test.ts
+++ b/apps/frontend/src/features/forms/api/getResearchNotes.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AppClient } from "@/lib/api/client";
+import { getResearchNotes } from "./getResearchNotes";
+
+const getMock = mock();
+
+const createMockClient = (): AppClient => ({
+  api: {
+    v1: {
+      "research-notes": {
+        $get: getMock,
+        $post: mock(),
+      },
+    },
+  },
+} as unknown as AppClient);
+
+describe("getResearchNotes", () => {
+  beforeEach(() => {
+    getMock.mockClear();
+  });
+
+  it("APIが成功した場合、保存済みリサーチメモ一覧を返すこと", async () => {
+    // ## Arrange ##
+    const response = {
+      notes: [
+        {
+          id: "note-1",
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+          createdAt: "2026-05-05T10:00:00Z",
+          updatedAt: "2026-05-05T10:00:00Z",
+        },
+      ],
+    };
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => response,
+    });
+
+    // ## Act ##
+    const result = await getResearchNotes(createMockClient());
+
+    // ## Assert ##
+    expect(result).toEqual(response);
+    expect(getMock).toHaveBeenCalledWith(undefined, {
+      init: expect.objectContaining({
+        cache: "no-store",
+      }),
+    });
+  });
+
+  it("APIが失敗した場合、取得エラーを投げること", async () => {
+    // ## Arrange ##
+    getMock.mockResolvedValue({
+      ok: false,
+    });
+
+    // ## Act & Assert ##
+    await expect(getResearchNotes(createMockClient())).rejects.toThrow("リサーチメモの取得に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/forms/api/getResearchNotes.ts
+++ b/apps/frontend/src/features/forms/api/getResearchNotes.ts
@@ -1,0 +1,20 @@
+import { apiClient, type AppClient } from "@/lib/api/client";
+
+/**
+ * getResearchNotes は保存済みリサーチメモ一覧を取得します。
+ * @responsibility メモ一覧APIの通信結果を検証し、表示用データを返す。
+ */
+export async function getResearchNotes(client: AppClient = apiClient) {
+  const res = await client.api.v1["research-notes"].$get(undefined, {
+    init: {
+      cache: "no-store",
+      signal: AbortSignal.timeout(5000),
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error("リサーチメモの取得に失敗しました");
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/forms/api/updateResearchNote.test.ts
+++ b/apps/frontend/src/features/forms/api/updateResearchNote.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AppClient } from "@/lib/api/client";
+import { updateResearchNote } from "./updateResearchNote";
+
+const patchMock = mock();
+
+const createMockClient = (): AppClient => ({
+  api: {
+    v1: {
+      "research-notes": {
+        $get: mock(),
+        $post: mock(),
+        ":noteId": {
+          $patch: patchMock,
+          $delete: mock(),
+        },
+      },
+    },
+  },
+} as unknown as AppClient);
+
+describe("updateResearchNote", () => {
+  beforeEach(() => {
+    patchMock.mockClear();
+  });
+
+  it("APIが成功した場合、更新済みリサーチメモを返すこと", async () => {
+    // ## Arrange ##
+    const note = {
+      id: "note-1",
+      title: "CPI発表後の観察メモ",
+      body: "初動とNY後半の戻りを比較する",
+      createdAt: "2026-05-05T10:00:00Z",
+      updatedAt: "2026-05-05T10:30:00Z",
+    };
+    patchMock.mockResolvedValue({
+      ok: true,
+      json: async () => note,
+    });
+
+    // ## Act ##
+    const result = await updateResearchNote("note-1", {
+      title: note.title,
+      body: note.body,
+    }, createMockClient());
+
+    // ## Assert ##
+    expect(result).toEqual(note);
+    expect(patchMock).toHaveBeenCalledWith(
+      {
+        param: { noteId: "note-1" },
+        json: {
+          title: note.title,
+          body: note.body,
+        },
+      },
+      expect.objectContaining({
+        init: expect.objectContaining({
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("APIが失敗した場合、更新エラーを投げること", async () => {
+    // ## Arrange ##
+    patchMock.mockResolvedValue({
+      ok: false,
+    });
+
+    // ## Act & Assert ##
+    await expect(updateResearchNote("note-1", {
+      title: "CPI発表後の観察メモ",
+      body: "初動とNY後半の戻りを比較する",
+    }, createMockClient())).rejects.toThrow("リサーチメモの更新に失敗しました");
+  });
+});

--- a/apps/frontend/src/features/forms/api/updateResearchNote.ts
+++ b/apps/frontend/src/features/forms/api/updateResearchNote.ts
@@ -1,0 +1,32 @@
+import { apiClient, type AppClient, type UpdateResearchNoteInput } from "@/lib/api/client";
+
+/**
+ * updateResearchNote は保存済みリサーチメモを更新します。
+ * @responsibility メモ更新APIの通信結果を検証し、更新済みメモを返す。
+ */
+export async function updateResearchNote(
+  noteId: string,
+  input: UpdateResearchNoteInput,
+  client: AppClient = apiClient,
+) {
+  const res = await client.api.v1["research-notes"][":noteId"].$patch(
+    {
+      param: { noteId },
+      json: input,
+    },
+    {
+      init: {
+        headers: {
+          "content-type": "application/json",
+        },
+        signal: AbortSignal.timeout(5000),
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error("リサーチメモの更新に失敗しました");
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/forms/components/ResearchNoteForm.test.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNoteForm.test.tsx
@@ -1,13 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ToastProvider } from "@/features/common/components/ToastProvider";
 import { ResearchNoteForm } from "./ResearchNoteForm";
 
+const createResearchNoteMock = mock();
+
 describe("ResearchNoteForm", () => {
+  beforeEach(() => {
+    createResearchNoteMock.mockClear();
+  });
+
   it("入力値が不正な場合に zod のバリデーションエラーを表示すること", async () => {
     render(
       <ToastProvider>
-        <ResearchNoteForm />
+        <ResearchNoteForm createNote={createResearchNoteMock} />
       </ToastProvider>,
     );
 
@@ -15,12 +21,23 @@ describe("ResearchNoteForm", () => {
 
     expect(await screen.findByText("タイトルを入力してください")).toBeDefined();
     expect(await screen.findByText("メモは10文字以上で入力してください")).toBeDefined();
+    expect(createResearchNoteMock).not.toHaveBeenCalled();
   });
 
-  it("入力値が正しい場合に保存トーストを表示すること", async () => {
+  it("入力値が正しい場合に保存APIを呼び出し、作成済みメモを親へ渡すこと", async () => {
+    const onCreated = mock();
+    const createdNote = {
+      id: "note-new",
+      title: "CPI前後の値動き",
+      body: "発表直後とNY後半の戻りを比較する",
+      createdAt: "2026-05-05T10:00:00Z",
+      updatedAt: "2026-05-05T10:00:00Z",
+    };
+    createResearchNoteMock.mockResolvedValue(createdNote);
+
     render(
       <ToastProvider>
-        <ResearchNoteForm />
+        <ResearchNoteForm createNote={createResearchNoteMock} onCreated={onCreated} />
       </ToastProvider>,
     );
 
@@ -33,7 +50,32 @@ describe("ResearchNoteForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "メモを保存" }));
 
     await waitFor(() => {
+      expect(createResearchNoteMock).toHaveBeenCalledWith({
+        title: "CPI前後の値動き",
+        body: "発表直後とNY後半の戻りを比較する",
+      });
+      expect(onCreated).toHaveBeenCalledWith(createdNote);
       expect(screen.getByText("リサーチメモを保存しました")).toBeDefined();
     });
+  });
+
+  it("保存APIが失敗した場合、エラー通知を表示すること", async () => {
+    createResearchNoteMock.mockRejectedValue(new Error("failed"));
+
+    render(
+      <ToastProvider>
+        <ResearchNoteForm createNote={createResearchNoteMock} />
+      </ToastProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("タイトル"), {
+      target: { value: "CPI前後の値動き" },
+    });
+    fireEvent.change(screen.getByLabelText("メモ"), {
+      target: { value: "発表直後とNY後半の戻りを比較する" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "メモを保存" }));
+
+    expect(await screen.findByText("リサーチメモを保存できませんでした")).toBeDefined();
   });
 });

--- a/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
@@ -7,12 +7,12 @@ import { useToast } from "@/features/common/components/ToastProvider";
 import { createResearchNote } from "@/features/forms/api/createResearchNote";
 import type { ResearchNote } from "@/lib/api/client";
 
-const researchNoteSchema = z.object({
+export const researchNoteSchema = z.object({
   title: z.string().min(1, "タイトルを入力してください").max(60, "タイトルは60文字以内で入力してください"),
   body: z.string().min(10, "メモは10文字以上で入力してください").max(240, "メモは240文字以内で入力してください"),
 });
 
-type ResearchNoteFormValues = z.infer<typeof researchNoteSchema>;
+export type ResearchNoteFormValues = z.infer<typeof researchNoteSchema>;
 
 type ResearchNoteFormProps = {
   createNote?: typeof createResearchNote;

--- a/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNoteForm.tsx
@@ -4,19 +4,26 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useToast } from "@/features/common/components/ToastProvider";
+import { createResearchNote } from "@/features/forms/api/createResearchNote";
+import type { ResearchNote } from "@/lib/api/client";
 
 const researchNoteSchema = z.object({
   title: z.string().min(1, "タイトルを入力してください").max(60, "タイトルは60文字以内で入力してください"),
-  note: z.string().min(10, "メモは10文字以上で入力してください").max(240, "メモは240文字以内で入力してください"),
+  body: z.string().min(10, "メモは10文字以上で入力してください").max(240, "メモは240文字以内で入力してください"),
 });
 
 type ResearchNoteFormValues = z.infer<typeof researchNoteSchema>;
 
+type ResearchNoteFormProps = {
+  createNote?: typeof createResearchNote;
+  onCreated?: (note: ResearchNote) => void;
+};
+
 /**
- * ResearchNoteForm は React Hook Form と zod を組み合わせたサンプルフォームです。
- * @responsibility 今後の設定画面や投稿フォームで再利用する入力検証・送信フィードバックの土台を示す。
+ * ResearchNoteForm はリサーチメモを保存するフォームです。
+ * @responsibility 入力検証、保存API呼び出し、成功・失敗の通知を担当する。
  */
-export function ResearchNoteForm() {
+export function ResearchNoteForm({ createNote = createResearchNote, onCreated }: ResearchNoteFormProps) {
   const { showToast } = useToast();
   const {
     formState: { errors, isSubmitting },
@@ -27,28 +34,38 @@ export function ResearchNoteForm() {
     resolver: zodResolver(researchNoteSchema),
     defaultValues: {
       title: "",
-      note: "",
+      body: "",
     },
   });
 
   const onSubmit = handleSubmit(async (values) => {
-    showToast({
-      title: "リサーチメモを保存しました",
-      description: `${values.title} をローカル確認用のサンプルとして受け付けました。`,
-      variant: "success",
-    });
-    reset();
+    try {
+      const note = await createNote(values);
+      onCreated?.(note);
+      showToast({
+        title: "リサーチメモを保存しました",
+        description: `${note.title} を保存しました。`,
+        variant: "success",
+      });
+      reset();
+    } catch {
+      showToast({
+        title: "リサーチメモを保存できませんでした",
+        description: "入力内容を確認して、時間をおいて再度お試しください。",
+        variant: "error",
+      });
+    }
   });
 
   return (
     <form onSubmit={onSubmit} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-700">
-          Form Foundation
+          Research Notes
         </p>
-        <h3 className="mt-2 text-lg font-semibold text-slate-950">リサーチメモのサンプルフォーム</h3>
+        <h3 className="mt-2 text-lg font-semibold text-slate-950">リサーチメモを保存</h3>
         <p className="mt-2 text-sm leading-6 text-slate-500">
-          React Hook Form と zod による型安全な入力検証の基盤です。
+          指標前後の気づきや検証したい仮説を残します。
         </p>
       </div>
 
@@ -65,11 +82,11 @@ export function ResearchNoteForm() {
       <label className="block space-y-2">
         <span className="text-sm font-semibold text-slate-700">メモ</span>
         <textarea
-          {...register("note")}
+          {...register("body")}
           className="min-h-28 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition-colors focus:border-amber-500"
           placeholder="見返したい観点を10文字以上で入力"
         />
-        {errors.note ? <p className="text-xs font-medium text-red-600">{errors.note.message}</p> : null}
+        {errors.body ? <p className="text-xs font-medium text-red-600">{errors.body.message}</p> : null}
       </label>
 
       <button
@@ -77,7 +94,7 @@ export function ResearchNoteForm() {
         disabled={isSubmitting}
         className="inline-flex rounded-xl bg-slate-950 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
       >
-        メモを保存
+        {isSubmitting ? "保存中..." : "メモを保存"}
       </button>
     </form>
   );

--- a/apps/frontend/src/features/forms/components/ResearchNotesPanel.test.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNotesPanel.test.tsx
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ToastProvider } from "@/features/common/components/ToastProvider";
 import { ResearchNotesPanel, formatResearchNoteDate } from "./ResearchNotesPanel";
 
 const loadNotesMock = mock();
+const updateNoteMock = mock();
+const deleteNoteMock = mock();
 
 describe("ResearchNotesPanel", () => {
   beforeEach(() => {
     loadNotesMock.mockClear();
+    updateNoteMock.mockClear();
+    deleteNoteMock.mockClear();
   });
 
   it("保存済みメモ一覧を表示すること", async () => {
@@ -76,5 +80,117 @@ describe("ResearchNotesPanel", () => {
 
     // ## Assert ##
     expect(result).toContain("05/05");
+  });
+
+  it("保存済みメモを編集できること", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockResolvedValue({
+      notes: [
+        {
+          id: "note-1",
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+          createdAt: "2026-05-05T10:00:00Z",
+          updatedAt: "2026-05-05T10:00:00Z",
+        },
+      ],
+    });
+    updateNoteMock.mockResolvedValue({
+      id: "note-1",
+      title: "CPI発表後の観察メモ",
+      body: "初動とNY後半の戻りを比較する",
+      createdAt: "2026-05-05T10:00:00Z",
+      updatedAt: "2026-05-05T11:00:00Z",
+    });
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel
+          loadNotes={loadNotesMock}
+          updateNote={updateNoteMock}
+          deleteNote={deleteNoteMock}
+        />
+      </ToastProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "編集" }));
+    fireEvent.change(screen.getByDisplayValue("CPI前後の値動き"), {
+      target: { value: "CPI発表後の観察メモ" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "更新する" }));
+
+    // ## Assert ##
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledWith("note-1", {
+        title: "CPI発表後の観察メモ",
+        body: "発表直後とNY後半の戻りを比較する",
+      });
+    });
+    expect(await screen.findByText("リサーチメモを更新しました")).toBeDefined();
+    expect(screen.getByText("CPI発表後の観察メモ")).toBeDefined();
+  });
+
+  it("編集フォームでもzodバリデーションが効くこと", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockResolvedValue({
+      notes: [
+        {
+          id: "note-1",
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+          createdAt: "2026-05-05T10:00:00Z",
+          updatedAt: "2026-05-05T10:00:00Z",
+        },
+      ],
+    });
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel loadNotes={loadNotesMock} updateNote={updateNoteMock} />
+      </ToastProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "編集" }));
+    fireEvent.change(screen.getByDisplayValue("CPI前後の値動き"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "更新する" }));
+
+    // ## Assert ##
+    expect(await screen.findByText("タイトルを入力してください")).toBeDefined();
+    expect(updateNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("削除前に確認UIを表示し、確定後に一覧から取り除くこと", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockResolvedValue({
+      notes: [
+        {
+          id: "note-1",
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+          createdAt: "2026-05-05T10:00:00Z",
+          updatedAt: "2026-05-05T10:00:00Z",
+        },
+      ],
+    });
+    deleteNoteMock.mockResolvedValue({ success: true });
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel loadNotes={loadNotesMock} deleteNote={deleteNoteMock} />
+      </ToastProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "削除" }));
+    expect(screen.getByText("リサーチメモを削除しますか？")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+    // ## Assert ##
+    await waitFor(() => {
+      expect(deleteNoteMock).toHaveBeenCalledWith("note-1");
+    });
+    expect(await screen.findByText("リサーチメモを削除しました")).toBeDefined();
+    expect(screen.getByText("まだ保存済みメモはありません。")).toBeDefined();
   });
 });

--- a/apps/frontend/src/features/forms/components/ResearchNotesPanel.test.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNotesPanel.test.tsx
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { ToastProvider } from "@/features/common/components/ToastProvider";
+import { ResearchNotesPanel, formatResearchNoteDate } from "./ResearchNotesPanel";
+
+const loadNotesMock = mock();
+
+describe("ResearchNotesPanel", () => {
+  beforeEach(() => {
+    loadNotesMock.mockClear();
+  });
+
+  it("保存済みメモ一覧を表示すること", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockResolvedValue({
+      notes: [
+        {
+          id: "note-1",
+          title: "CPI前後の値動き",
+          body: "発表直後とNY後半の戻りを比較する",
+          createdAt: "2026-05-05T10:00:00Z",
+          updatedAt: "2026-05-05T10:00:00Z",
+        },
+      ],
+    });
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel loadNotes={loadNotesMock} />
+      </ToastProvider>,
+    );
+
+    // ## Assert ##
+    expect(screen.getByLabelText("リサーチメモを読み込み中")).toBeDefined();
+    expect(await screen.findByText("CPI前後の値動き")).toBeDefined();
+    expect(screen.getByText("発表直後とNY後半の戻りを比較する")).toBeDefined();
+  });
+
+  it("保存済みメモが0件の場合、空状態を表示すること", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockResolvedValue({ notes: [] });
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel loadNotes={loadNotesMock} />
+      </ToastProvider>,
+    );
+
+    // ## Assert ##
+    expect(await screen.findByText("まだ保存済みメモはありません。")).toBeDefined();
+  });
+
+  it("取得に失敗した場合、エラー表示を出すこと", async () => {
+    // ## Arrange ##
+    loadNotesMock.mockRejectedValue(new Error("failed"));
+
+    // ## Act ##
+    render(
+      <ToastProvider>
+        <ResearchNotesPanel loadNotes={loadNotesMock} />
+      </ToastProvider>,
+    );
+
+    // ## Assert ##
+    expect(await screen.findByText("リサーチメモを読み込めませんでした")).toBeDefined();
+  });
+
+  it("保存日時を短い日本語表記へ変換すること", () => {
+    // ## Arrange ##
+    const value = "2026-05-05T10:00:00Z";
+
+    // ## Act ##
+    const result = formatResearchNoteDate(value);
+
+    // ## Assert ##
+    expect(result).toContain("05/05");
+  });
+});

--- a/apps/frontend/src/features/forms/components/ResearchNotesPanel.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNotesPanel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getResearchNotes } from "@/features/forms/api/getResearchNotes";
+import { ResearchNoteForm } from "@/features/forms/components/ResearchNoteForm";
+import type { ResearchNote, ResearchNotesResponse } from "@/lib/api/client";
+
+type ResearchNotesPanelProps = {
+  loadNotes?: typeof getResearchNotes;
+};
+
+/**
+ * formatResearchNoteDate は保存日時を短い日本語表記へ変換します。
+ * @responsibility 一覧カードで読みやすい作成日時ラベルを生成する。
+ */
+export function formatResearchNoteDate(value: string): string {
+  return new Intl.DateTimeFormat("ja-JP", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+/**
+ * ResearchNotesPanel はメモ作成フォームと保存済みメモ一覧をまとめて表示します。
+ * @responsibility 初期取得、ローディング/エラー/空状態、作成後の一覧反映を担当する。
+ */
+export function ResearchNotesPanel({ loadNotes = getResearchNotes }: ResearchNotesPanelProps) {
+  const [notes, setNotes] = useState<ResearchNote[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const response: ResearchNotesResponse = await loadNotes();
+        if (isMounted) {
+          setNotes(response.notes);
+        }
+      } catch {
+        if (isMounted) {
+          setError("リサーチメモを読み込めませんでした");
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadNotes]);
+
+  const handleCreated = (note: ResearchNote) => {
+    setNotes((current) => [note, ...current]);
+  };
+
+  return (
+    <div className="space-y-6">
+      <ResearchNoteForm onCreated={handleCreated} />
+
+      <section className="rounded-3xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-200/60">
+        <div className="mb-5">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+            Saved Notes
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-slate-950">保存済みリサーチメモ</h3>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3" aria-label="リサーチメモを読み込み中">
+            <div className="h-16 animate-pulse rounded-2xl bg-slate-100" />
+            <div className="h-16 animate-pulse rounded-2xl bg-slate-100" />
+          </div>
+        ) : null}
+
+        {!isLoading && error ? (
+          <p className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-700">
+            {error}
+          </p>
+        ) : null}
+
+        {!isLoading && !error && notes.length === 0 ? (
+          <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-500">
+            まだ保存済みメモはありません。
+          </p>
+        ) : null}
+
+        {!isLoading && !error && notes.length > 0 ? (
+          <div className="space-y-3">
+            {notes.map((note) => (
+              <article key={note.id} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="mb-2 flex items-start justify-between gap-3">
+                  <h4 className="text-sm font-semibold leading-6 text-slate-950">{note.title}</h4>
+                  <time className="shrink-0 text-xs font-medium text-slate-400" dateTime={note.createdAt}>
+                    {formatResearchNoteDate(note.createdAt)}
+                  </time>
+                </div>
+                <p className="line-clamp-3 text-sm leading-6 text-slate-600">{note.body}</p>
+              </article>
+            ))}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/forms/components/ResearchNotesPanel.tsx
+++ b/apps/frontend/src/features/forms/components/ResearchNotesPanel.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { deleteResearchNote } from "@/features/forms/api/deleteResearchNote";
 import { getResearchNotes } from "@/features/forms/api/getResearchNotes";
-import { ResearchNoteForm } from "@/features/forms/components/ResearchNoteForm";
-import type { ResearchNote, ResearchNotesResponse } from "@/lib/api/client";
+import { updateResearchNote } from "@/features/forms/api/updateResearchNote";
+import { useToast } from "@/features/common/components/ToastProvider";
+import {
+  ResearchNoteForm,
+  researchNoteSchema,
+  type ResearchNoteFormValues,
+} from "@/features/forms/components/ResearchNoteForm";
+import type { ResearchNote, ResearchNotesResponse, UpdateResearchNoteInput } from "@/lib/api/client";
 
 type ResearchNotesPanelProps = {
   loadNotes?: typeof getResearchNotes;
+  updateNote?: typeof updateResearchNote;
+  deleteNote?: typeof deleteResearchNote;
 };
 
 /**
@@ -26,10 +35,23 @@ export function formatResearchNoteDate(value: string): string {
  * ResearchNotesPanel はメモ作成フォームと保存済みメモ一覧をまとめて表示します。
  * @responsibility 初期取得、ローディング/エラー/空状態、作成後の一覧反映を担当する。
  */
-export function ResearchNotesPanel({ loadNotes = getResearchNotes }: ResearchNotesPanelProps) {
+export function ResearchNotesPanel({
+  loadNotes = getResearchNotes,
+  updateNote = updateResearchNote,
+  deleteNote = deleteResearchNote,
+}: ResearchNotesPanelProps) {
+  const { showToast } = useToast();
   const [notes, setNotes] = useState<ResearchNote[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingNote, setEditingNote] = useState<ResearchNote | null>(null);
+  const [editValues, setEditValues] = useState<ResearchNoteFormValues>({
+    title: "",
+    body: "",
+  });
+  const [editErrors, setEditErrors] = useState<Partial<Record<keyof ResearchNoteFormValues, string>>>({});
+  const [deletingNote, setDeletingNote] = useState<ResearchNote | null>(null);
+  const [isMutating, setIsMutating] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -62,6 +84,72 @@ export function ResearchNotesPanel({ loadNotes = getResearchNotes }: ResearchNot
 
   const handleCreated = (note: ResearchNote) => {
     setNotes((current) => [note, ...current]);
+  };
+
+  const startEditing = (note: ResearchNote) => {
+    setEditingNote(note);
+    setEditValues({
+      title: note.title,
+      body: note.body,
+    });
+    setEditErrors({});
+  };
+
+  const submitEdit = async () => {
+    if (!editingNote) return;
+
+    const parsed = researchNoteSchema.safeParse(editValues);
+    if (!parsed.success) {
+      setEditErrors({
+        title: parsed.error.flatten().fieldErrors.title?.[0],
+        body: parsed.error.flatten().fieldErrors.body?.[0],
+      });
+      return;
+    }
+
+    try {
+      setIsMutating(true);
+      const updated = await updateNote(editingNote.id, parsed.data as UpdateResearchNoteInput);
+      setNotes((current) => current.map((note) => (note.id === updated.id ? updated : note)));
+      setEditingNote(null);
+      showToast({
+        title: "リサーチメモを更新しました",
+        description: `${updated.title} を更新しました。`,
+        variant: "success",
+      });
+    } catch {
+      showToast({
+        title: "リサーチメモを更新できませんでした",
+        description: "入力内容を確認して、時間をおいて再度お試しください。",
+        variant: "error",
+      });
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingNote) return;
+
+    try {
+      setIsMutating(true);
+      await deleteNote(deletingNote.id);
+      setNotes((current) => current.filter((note) => note.id !== deletingNote.id));
+      showToast({
+        title: "リサーチメモを削除しました",
+        description: `${deletingNote.title} を削除しました。`,
+        variant: "success",
+      });
+      setDeletingNote(null);
+    } catch {
+      showToast({
+        title: "リサーチメモを削除できませんでした",
+        description: "時間をおいて再度お試しください。",
+        variant: "error",
+      });
+    } finally {
+      setIsMutating(false);
+    }
   };
 
   return (
@@ -106,11 +194,82 @@ export function ResearchNotesPanel({ loadNotes = getResearchNotes }: ResearchNot
                   </time>
                 </div>
                 <p className="line-clamp-3 text-sm leading-6 text-slate-600">{note.body}</p>
+                <div className="mt-3 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => startEditing(note)}
+                    className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-colors hover:border-amber-400"
+                  >
+                    編集
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDeletingNote(note)}
+                    className="rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50"
+                  >
+                    削除
+                  </button>
+                </div>
               </article>
             ))}
           </div>
         ) : null}
       </section>
+
+      {editingNote ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4">
+          <div role="dialog" aria-modal="true" aria-labelledby="edit-research-note-title" className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl">
+            <h3 id="edit-research-note-title" className="text-lg font-semibold text-slate-950">リサーチメモを編集</h3>
+            <div className="mt-4 space-y-4">
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-slate-700">タイトル</span>
+                <input
+                  value={editValues.title}
+                  onChange={(event) => setEditValues((current) => ({ ...current, title: event.target.value }))}
+                  className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition-colors focus:border-amber-500"
+                />
+                {editErrors.title ? <p className="text-xs font-medium text-red-600">{editErrors.title}</p> : null}
+              </label>
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-slate-700">メモ</span>
+                <textarea
+                  value={editValues.body}
+                  onChange={(event) => setEditValues((current) => ({ ...current, body: event.target.value }))}
+                  className="min-h-28 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition-colors focus:border-amber-500"
+                />
+                {editErrors.body ? <p className="text-xs font-medium text-red-600">{editErrors.body}</p> : null}
+              </label>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button type="button" onClick={() => setEditingNote(null)} className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700">
+                キャンセル
+              </button>
+              <button type="button" onClick={submitEdit} disabled={isMutating} className="rounded-xl bg-slate-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60">
+                {isMutating ? "更新中..." : "更新する"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {deletingNote ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4">
+          <div role="alertdialog" aria-modal="true" aria-labelledby="delete-research-note-title" className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-xl">
+            <h3 id="delete-research-note-title" className="text-lg font-semibold text-slate-950">リサーチメモを削除しますか？</h3>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {deletingNote.title} は削除後に戻せません。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button type="button" onClick={() => setDeletingNote(null)} className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700">
+                キャンセル
+              </button>
+              <button type="button" onClick={confirmDelete} disabled={isMutating} className="rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60">
+                {isMutating ? "削除中..." : "削除する"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -26,6 +26,10 @@ export type AppClient = {
       "research-notes": {
         $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ResearchNotesResponse> }>;
         $post: (args: { json: CreateResearchNoteInput }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ResearchNote> }>;
+        ":noteId": {
+          $patch: (args: { param: { noteId: string }; json: UpdateResearchNoteInput }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ResearchNote> }>;
+          $delete: (args: { param: { noteId: string } }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<{ success: boolean }> }>;
+        };
       };
       sync: {
         status: { $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<SyncStatusResponse> }> };
@@ -138,6 +142,8 @@ export type CreateResearchNoteInput = {
   title: string;
   body: string;
 };
+
+export type UpdateResearchNoteInput = CreateResearchNoteInput;
 
 export type Candle = {
   datetimeJst: string;

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -23,6 +23,10 @@ export type AppClient = {
           };
         };
       };
+      "research-notes": {
+        $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ResearchNotesResponse> }>;
+        $post: (args: { json: CreateResearchNoteInput }, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<ResearchNote> }>;
+      };
       sync: {
         status: { $get: (args?: Record<string, never>, options?: { init?: RequestInit }) => Promise<{ ok: boolean; json: () => Promise<SyncStatusResponse> }> };
       }
@@ -100,6 +104,18 @@ export type CommunityThreadDetailResponse = {
   replies: CommunityReply[];
 };
 
+export type ResearchNote = {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ResearchNotesResponse = {
+  notes: ResearchNote[];
+};
+
 export type SyncStatusResponse = {
   lastCandleAt: string;
   lastSessionAt: string;
@@ -115,6 +131,11 @@ export type CreateCommunityThreadInput = {
 };
 
 export type CreateCommunityReplyInput = {
+  body: string;
+};
+
+export type CreateResearchNoteInput = {
+  title: string;
   body: string;
 };
 

--- a/apps/frontend/src/test/handlers.test.ts
+++ b/apps/frontend/src/test/handlers.test.ts
@@ -205,4 +205,56 @@ describe("MSW abnormal scenarios", () => {
 
     expect(res.status).toBe(400);
   });
+
+  it("リサーチメモ一覧APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes");
+    const body = await res.json() as { notes: Array<{ title: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.notes[0].title).toBe("CPI前後の値動き");
+  });
+
+  it("x-test-scenario=empty で空のリサーチメモ一覧を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes", {
+      headers: {
+        "x-test-scenario": "empty",
+      },
+    });
+    const body = await res.json() as { notes: unknown[] };
+
+    expect(res.status).toBe(200);
+    expect(body.notes).toEqual([]);
+  });
+
+  it("リサーチメモ作成APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "CPI前後の値動き",
+        body: "発表直後とNY後半の戻りを比較する",
+      }),
+    });
+    const body = await res.json() as { title: string; body: string };
+
+    expect(res.status).toBe(201);
+    expect(body.title).toBe("CPI前後の値動き");
+  });
+
+  it("リサーチメモ作成APIのバリデーションエラーを再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "",
+        body: "",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/frontend/src/test/handlers.test.ts
+++ b/apps/frontend/src/test/handlers.test.ts
@@ -257,4 +257,32 @@ describe("MSW abnormal scenarios", () => {
 
     expect(res.status).toBe(400);
   });
+
+  it("リサーチメモ更新APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes/note-1", {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "CPI発表後の観察メモ",
+        body: "初動とNY後半の戻りを比較する",
+      }),
+    });
+    const body = await res.json() as { id: string; title: string };
+
+    expect(res.status).toBe(200);
+    expect(body.id).toBe("note-1");
+    expect(body.title).toBe("CPI発表後の観察メモ");
+  });
+
+  it("リサーチメモ削除APIの正常応答を再現できること", async () => {
+    const res = await fetch("http://localhost:3000/api/v1/research-notes/note-1", {
+      method: "DELETE",
+    });
+    const body = await res.json() as { success: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
 });

--- a/apps/frontend/src/test/handlers.ts
+++ b/apps/frontend/src/test/handlers.ts
@@ -225,6 +225,37 @@ export const handlers = [
     }, { status: 201 });
   }),
 
+  /* リサーチメモ更新 */
+  http.patch(`${baseUrl}/api/v1/research-notes/:noteId`, async ({ params, request }) => {
+    const scenario = request.headers.get('x-test-scenario');
+    if (scenario === 'error' || params.noteId === 'missing') {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    const body = await request.json() as { title?: string; body?: string };
+    if (!body.title || !body.body) {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    return HttpResponse.json({
+      id: String(params.noteId),
+      title: body.title,
+      body: body.body,
+      createdAt: '2026-05-05T10:00:00Z',
+      updatedAt: '2026-05-05T11:00:00Z',
+    });
+  }),
+
+  /* リサーチメモ削除 */
+  http.delete(`${baseUrl}/api/v1/research-notes/:noteId`, ({ params, request }) => {
+    const scenario = request.headers.get('x-test-scenario');
+    if (scenario === 'error' || params.noteId === 'missing') {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    return HttpResponse.json({ success: true });
+  }),
+
   http.get(`${baseUrl}/api/auth/get-session`, ({ request }) => {
     const cookie = request.headers.get('cookie');
     if (cookie && cookie.includes('mock_session_token')) {

--- a/apps/frontend/src/test/handlers.ts
+++ b/apps/frontend/src/test/handlers.ts
@@ -180,6 +180,51 @@ export const handlers = [
     }, { status: 201 });
   }),
 
+  /* リサーチメモ一覧 */
+  http.get(`${baseUrl}/api/v1/research-notes`, ({ request }) => {
+    const scenario = request.headers.get('x-test-scenario');
+
+    if (scenario === 'error') {
+      return new HttpResponse(null, { status: 500 });
+    }
+    if (scenario === 'empty') {
+      return HttpResponse.json({ notes: [] });
+    }
+
+    return HttpResponse.json({
+      notes: [
+        {
+          id: 'note-1',
+          title: 'CPI前後の値動き',
+          body: '発表直後とNY後半の戻りを比較する',
+          createdAt: '2026-05-05T10:00:00Z',
+          updatedAt: '2026-05-05T10:00:00Z',
+        },
+      ],
+    });
+  }),
+
+  /* リサーチメモ作成 */
+  http.post(`${baseUrl}/api/v1/research-notes`, async ({ request }) => {
+    const scenario = request.headers.get('x-test-scenario');
+    if (scenario === 'error') {
+      return new HttpResponse(null, { status: 500 });
+    }
+
+    const body = await request.json() as { title?: string; body?: string };
+    if (!body.title || !body.body) {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    return HttpResponse.json({
+      id: 'note-new',
+      title: body.title,
+      body: body.body,
+      createdAt: '2026-05-05T10:30:00Z',
+      updatedAt: '2026-05-05T10:30:00Z',
+    }, { status: 201 });
+  }),
+
   http.get(`${baseUrl}/api/auth/get-session`, ({ request }) => {
     const cookie = request.headers.get('cookie');
     if (cookie && cookie.includes('mock_session_token')) {


### PR DESCRIPTION
# Issue (対象のIssue)

Closes #38

# Todo

- [x] フォーム送信時に保存APIを呼び出す
- [x] 保存成功時にToastで成功表示
- [x] 保存失敗時にToastでエラー表示
- [x] zodバリデーションを維持
- [x] フォーム送信中はボタンをdisabled表示
- [x] APIラッパーとフォームの単体テストを追加

# How to check (動作確認の手順)

```zsh
PATH="/home/somah/.bun/bin:$PATH" bun run lint:all
PATH="/home/somah/.bun/bin:$PATH" bun run test:all
```

# Evidences (Screenshots, Test Results, etc)

<details>
<summary>エビデンスを展開する</summary>

- 実行日時: 2026-05-10 18:22 (JST)
- ブランチ: features/issue-40-edit-delete-research-notes

```zsh
bun run lint:all
# pass

bun run test:all
# frontend: 118 pass / 0 fail
# backend: 127 pass / 0 fail
```

</details>

# Related Links

- Stacked on: #104
- Depends on: #37
- Follow-up: #39, #40
